### PR TITLE
Feat/network domb

### DIFF
--- a/STUDYA/STUDYA.xcodeproj/project.pbxproj
+++ b/STUDYA/STUDYA.xcodeproj/project.pbxproj
@@ -19,6 +19,12 @@
 		726FA4632901A352004E49A9 /* ScheduleTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726FA4622901A352004E49A9 /* ScheduleTableView.swift */; };
 		726FA4652901A496004E49A9 /* ScheduleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726FA4642901A496004E49A9 /* ScheduleTableViewCell.swift */; };
 		726FA46B291B699A004E49A9 /* StudyInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726FA46A291B699A004E49A9 /* StudyInfoViewController.swift */; };
+		72758D29295ACF1F00BDFF9C /* EditingStudyGeneralRuleAttendanceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72758D28295ACF1F00BDFF9C /* EditingStudyGeneralRuleAttendanceCollectionViewCell.swift */; };
+		72758D2B295ACF5600BDFF9C /* EditingExcommunicationRuleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72758D2A295ACF5600BDFF9C /* EditingExcommunicationRuleCollectionViewCell.swift */; };
+		72758D2D295ACF9D00BDFF9C /* EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72758D2C295ACF9D00BDFF9C /* EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift */; };
+		72758D2F295ACFB000BDFF9C /* EditingStudyGeneralRuleAttendanceFineTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72758D2E295ACFB000BDFF9C /* EditingStudyGeneralRuleAttendanceFineTableViewCell.swift */; };
+		72758D31295ACFC000BDFF9C /* EditingStudyGeneralRuleDepositTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72758D30295ACFC000BDFF9C /* EditingStudyGeneralRuleDepositTableViewCell.swift */; };
+		72758D33295B0D3900BDFF9C /* GeneralRuleAttendanceTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72758D32295B0D3900BDFF9C /* GeneralRuleAttendanceTableView.swift */; };
 		727BB2B129431F7B003DB78A /* CreatingStudyCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727BB2B029431F7B003DB78A /* CreatingStudyCompleteViewController.swift */; };
 		7282F18228FFE7D2003EF100 /* ToDoCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7282F18128FFE7D2003EF100 /* ToDoCollectionViewCell.swift */; };
 		7282F18428FFE7DC003EF100 /* ScheduleCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7282F18328FFE7DC003EF100 /* ScheduleCollectionViewCell.swift */; };
@@ -27,9 +33,11 @@
 		7299968228AF5C480008A1C1 /* AnnouncementBoardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7299968128AF5C480008A1C1 /* AnnouncementBoardTableViewCell.swift */; };
 		7299968428B09B110008A1C1 /* AnnouncementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7299968328B09B110008A1C1 /* AnnouncementViewController.swift */; };
 		7299968828BE44090008A1C1 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7299968728BE44090008A1C1 /* MainViewController.swift */; };
-		7299968E28C1EEC00008A1C1 /* StudyFreeRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7299968D28C1EEC00008A1C1 /* StudyFreeRuleViewController.swift */; };
+		7299968E28C1EEC00008A1C1 /* CreatingStudyFreeRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7299968D28C1EEC00008A1C1 /* CreatingStudyFreeRuleViewController.swift */; };
 		7299969028C5BA510008A1C1 /* StudyGeneralRuleAttendanceTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7299968F28C5BA510008A1C1 /* StudyGeneralRuleAttendanceTableViewController.swift */; };
 		72AAC6E629574D4300FAD71D /* TokenAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AAC6E529574D4300FAD71D /* TokenAuthenticator.swift */; };
+		72AAC6E8295A129100FAD71D /* EditingStudyFreeRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AAC6E7295A129100FAD71D /* EditingStudyFreeRuleViewController.swift */; };
+		72AAC6EA295A12C500FAD71D /* EditingStudyGeneralRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72AAC6E9295A12C500FAD71D /* EditingStudyGeneralRuleViewController.swift */; };
 		72E2BED5291CD50C009BCCB7 /* EditingStudyFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E2BED4291CD50C009BCCB7 /* EditingStudyFormViewController.swift */; };
 		72E2BEDB2921AE66009BCCB7 /* StudyExitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E2BEDA2921AE66009BCCB7 /* StudyExitViewController.swift */; };
 		72E2BEDD29264B9D009BCCB7 /* AttendanceReusableProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E2BEDC29264B9D009BCCB7 /* AttendanceReusableProgressView.swift */; };
@@ -96,7 +104,7 @@
 		D3BF053028BDF2B400AF7D3B /* AccountManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF052F28BDF2B400AF7D3B /* AccountManagementViewController.swift */; };
 		D3BF053428BE39CA00AF7D3B /* ByeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF053328BE39CA00AF7D3B /* ByeViewController.swift */; };
 		D3BF053628BF901700AF7D3B /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF053528BF901700AF7D3B /* Formatter.swift */; };
-		D3BF054328C0E9EC00AF7D3B /* StudyGeneralRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF054128C0E9EC00AF7D3B /* StudyGeneralRuleViewController.swift */; };
+		D3BF054328C0E9EC00AF7D3B /* CreatingStudyGeneralRuleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF054128C0E9EC00AF7D3B /* CreatingStudyGeneralRuleViewController.swift */; };
 		D3BF054628C116DB00AF7D3B /* StudyGeneralRuleExcommunicationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF054528C116DB00AF7D3B /* StudyGeneralRuleExcommunicationCollectionViewCell.swift */; };
 		D3BF054828C116FD00AF7D3B /* StudyGeneralRuleAttendanceCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF054728C116FD00AF7D3B /* StudyGeneralRuleAttendanceCollectionViewCell.swift */; };
 		D3BF054C28C3C36700AF7D3B /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BF054B28C3C36700AF7D3B /* Notification.swift */; };
@@ -144,6 +152,12 @@
 		726FA4622901A352004E49A9 /* ScheduleTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleTableView.swift; sourceTree = "<group>"; };
 		726FA4642901A496004E49A9 /* ScheduleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleTableViewCell.swift; sourceTree = "<group>"; };
 		726FA46A291B699A004E49A9 /* StudyInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyInfoViewController.swift; sourceTree = "<group>"; };
+		72758D28295ACF1F00BDFF9C /* EditingStudyGeneralRuleAttendanceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyGeneralRuleAttendanceCollectionViewCell.swift; sourceTree = "<group>"; };
+		72758D2A295ACF5600BDFF9C /* EditingExcommunicationRuleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingExcommunicationRuleCollectionViewCell.swift; sourceTree = "<group>"; };
+		72758D2C295ACF9D00BDFF9C /* EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift; sourceTree = "<group>"; };
+		72758D2E295ACFB000BDFF9C /* EditingStudyGeneralRuleAttendanceFineTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyGeneralRuleAttendanceFineTableViewCell.swift; sourceTree = "<group>"; };
+		72758D30295ACFC000BDFF9C /* EditingStudyGeneralRuleDepositTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyGeneralRuleDepositTableViewCell.swift; sourceTree = "<group>"; };
+		72758D32295B0D3900BDFF9C /* GeneralRuleAttendanceTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralRuleAttendanceTableView.swift; sourceTree = "<group>"; };
 		727BB2B029431F7B003DB78A /* CreatingStudyCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingStudyCompleteViewController.swift; sourceTree = "<group>"; };
 		7282F18128FFE7D2003EF100 /* ToDoCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToDoCollectionViewCell.swift; sourceTree = "<group>"; };
 		7282F18328FFE7DC003EF100 /* ScheduleCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -152,9 +166,11 @@
 		7299968128AF5C480008A1C1 /* AnnouncementBoardTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementBoardTableViewCell.swift; sourceTree = "<group>"; };
 		7299968328B09B110008A1C1 /* AnnouncementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementViewController.swift; sourceTree = "<group>"; };
 		7299968728BE44090008A1C1 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
-		7299968D28C1EEC00008A1C1 /* StudyFreeRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyFreeRuleViewController.swift; sourceTree = "<group>"; };
+		7299968D28C1EEC00008A1C1 /* CreatingStudyFreeRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingStudyFreeRuleViewController.swift; sourceTree = "<group>"; };
 		7299968F28C5BA510008A1C1 /* StudyGeneralRuleAttendanceTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGeneralRuleAttendanceTableViewController.swift; sourceTree = "<group>"; };
 		72AAC6E529574D4300FAD71D /* TokenAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenAuthenticator.swift; sourceTree = "<group>"; };
+		72AAC6E7295A129100FAD71D /* EditingStudyFreeRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyFreeRuleViewController.swift; sourceTree = "<group>"; };
+		72AAC6E9295A12C500FAD71D /* EditingStudyGeneralRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyGeneralRuleViewController.swift; sourceTree = "<group>"; };
 		72E2BED4291CD50C009BCCB7 /* EditingStudyFormViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditingStudyFormViewController.swift; sourceTree = "<group>"; };
 		72E2BEDA2921AE66009BCCB7 /* StudyExitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyExitViewController.swift; sourceTree = "<group>"; };
 		72E2BEDC29264B9D009BCCB7 /* AttendanceReusableProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttendanceReusableProgressView.swift; sourceTree = "<group>"; };
@@ -223,7 +239,7 @@
 		D3BF052F28BDF2B400AF7D3B /* AccountManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewController.swift; sourceTree = "<group>"; };
 		D3BF053328BE39CA00AF7D3B /* ByeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByeViewController.swift; sourceTree = "<group>"; };
 		D3BF053528BF901700AF7D3B /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
-		D3BF054128C0E9EC00AF7D3B /* StudyGeneralRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGeneralRuleViewController.swift; sourceTree = "<group>"; };
+		D3BF054128C0E9EC00AF7D3B /* CreatingStudyGeneralRuleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingStudyGeneralRuleViewController.swift; sourceTree = "<group>"; };
 		D3BF054528C116DB00AF7D3B /* StudyGeneralRuleExcommunicationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGeneralRuleExcommunicationCollectionViewCell.swift; sourceTree = "<group>"; };
 		D3BF054728C116FD00AF7D3B /* StudyGeneralRuleAttendanceCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyGeneralRuleAttendanceCollectionViewCell.swift; sourceTree = "<group>"; };
 		D3BF054B28C3C36700AF7D3B /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
@@ -321,7 +337,6 @@
 				72F7CFAC28F834A800E0D0C0 /* CalendarBottomSheetViewController.swift */,
 				721D8A4C28A4EA0100829A2B /* CategoryCell.swift */,
 				721D8A4628A39F4C00829A2B /* CreatingStudyFormViewController.swift */,
-				72E2BED4291CD50C009BCCB7 /* EditingStudyFormViewController.swift */,
 				727BB2B029431F7B003DB78A /* CreatingStudyCompleteViewController.swift */,
 				72ED89A32943A2CD0072227C /* LinkShareMessageView.swift */,
 				D381A96A291EA72C008A2102 /* InviteMemberCollectionViewCell.swift */,
@@ -362,13 +377,22 @@
 				D3F2C6F928B2879F00CEC549 /* SignUpViewController.swift */,
 				72E2BEDA2921AE66009BCCB7 /* StudyExitViewController.swift */,
 				D335C67128A39E2600EEDD79 /* CreatingStudyRuleViewController.swift */,
-				7299968D28C1EEC00008A1C1 /* StudyFreeRuleViewController.swift */,
+				D3BF054128C0E9EC00AF7D3B /* CreatingStudyGeneralRuleViewController.swift */,
 				D3BF054728C116FD00AF7D3B /* StudyGeneralRuleAttendanceCollectionViewCell.swift */,
 				7299968F28C5BA510008A1C1 /* StudyGeneralRuleAttendanceTableViewController.swift */,
 				D3BF054528C116DB00AF7D3B /* StudyGeneralRuleExcommunicationCollectionViewCell.swift */,
-				D3BF054128C0E9EC00AF7D3B /* StudyGeneralRuleViewController.swift */,
+				7299968D28C1EEC00008A1C1 /* CreatingStudyFreeRuleViewController.swift */,
 				D398B46B28B4C29000598B03 /* StudyHistoryTableViewCell.swift */,
 				726FA46A291B699A004E49A9 /* StudyInfoViewController.swift */,
+				72E2BED4291CD50C009BCCB7 /* EditingStudyFormViewController.swift */,
+				72AAC6E9295A12C500FAD71D /* EditingStudyGeneralRuleViewController.swift */,
+				72758D28295ACF1F00BDFF9C /* EditingStudyGeneralRuleAttendanceCollectionViewCell.swift */,
+				72758D32295B0D3900BDFF9C /* GeneralRuleAttendanceTableView.swift */,
+				72758D2C295ACF9D00BDFF9C /* EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift */,
+				72758D2E295ACFB000BDFF9C /* EditingStudyGeneralRuleAttendanceFineTableViewCell.swift */,
+				72758D30295ACFC000BDFF9C /* EditingStudyGeneralRuleDepositTableViewCell.swift */,
+				72758D2A295ACF5600BDFF9C /* EditingExcommunicationRuleCollectionViewCell.swift */,
+				72AAC6E7295A129100FAD71D /* EditingStudyFreeRuleViewController.swift */,
 				72512A7F292CDFC40003F431 /* CreatingStudyScheduleContentViewController.swift */,
 				72512A7D292CDEEE0003F431 /* CreatingStudySchedulePriodFormViewController.swift */,
 				724DDD8829421B6000AC0B61 /* EditingStudySchduleViewController.swift */,
@@ -569,6 +593,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72758D31295ACFC000BDFF9C /* EditingStudyGeneralRuleDepositTableViewCell.swift in Sources */,
 				7299967C28A9FE6E0008A1C1 /* CustomAF.swift in Sources */,
 				D398B46A28B4C23A00598B03 /* MyPageStudyHistoryViewController.swift in Sources */,
 				721D8A4D28A4EA0100829A2B /* CategoryCell.swift in Sources */,
@@ -582,8 +607,10 @@
 				D39F6D852927C62C004C6E90 /* AttendanceManagerModeView.swift in Sources */,
 				72512A7E292CDEEE0003F431 /* CreatingStudySchedulePriodFormViewController.swift in Sources */,
 				D35D6F7F292E581000514980 /* AttendanceBottomIndividualUpdateView.swift in Sources */,
+				72AAC6E8295A129100FAD71D /* EditingStudyFreeRuleViewController.swift in Sources */,
 				D38FA4D52936559000A9B0DF /* MainFifthAttendanceTableViewCell.swift in Sources */,
 				726FA46B291B699A004E49A9 /* StudyInfoViewController.swift in Sources */,
+				72AAC6EA295A12C500FAD71D /* EditingStudyGeneralRuleViewController.swift in Sources */,
 				D37D8A4829081974004AF8E9 /* TabBarViewController.swift in Sources */,
 				D381A96B291EA72C008A2102 /* InviteMemberCollectionViewCell.swift in Sources */,
 				D371D2192924BC6D00E28231 /* ValidationNumberFillingInPopViewController.swift in Sources */,
@@ -595,12 +622,13 @@
 				726FA4652901A496004E49A9 /* ScheduleTableViewCell.swift in Sources */,
 				D3C23A5E28EDE685009B53B4 /* KeyChain.swift in Sources */,
 				72ED89A82943B6C10072227C /* AttendancePersonalViewController.swift in Sources */,
+				72758D33295B0D3900BDFF9C /* GeneralRuleAttendanceTableView.swift in Sources */,
 				72ED25AC2897788900031AD1 /* ViewController.swift in Sources */,
 				D3F2C6FA28B2879F00CEC549 /* SignUpViewController.swift in Sources */,
-				7299968E28C1EEC00008A1C1 /* StudyFreeRuleViewController.swift in Sources */,
+				7299968E28C1EEC00008A1C1 /* CreatingStudyFreeRuleViewController.swift in Sources */,
 				7282F18428FFE7DC003EF100 /* ScheduleCollectionViewCell.swift in Sources */,
 				D3C23A7328F9A7CD009B53B4 /* MainFirstStudyToggleTableViewCell.swift in Sources */,
-				7299968E28C1EEC00008A1C1 /* StudyFreeRuleViewController.swift in Sources */,
+				7299968E28C1EEC00008A1C1 /* CreatingStudyFreeRuleViewController.swift in Sources */,
 				D39F6D8C2927DB2B004C6E90 /* AttendanceModificationHeaderView.swift in Sources */,
 				D314D2D929374F2F0018062F /* MainSixthETCTableViewCell.swift in Sources */,
 				D314A1D92902931800093C0E /* ToDoItemTableViewCell.swift in Sources */,
@@ -614,6 +642,7 @@
 				D3BF054628C116DB00AF7D3B /* StudyGeneralRuleExcommunicationCollectionViewCell.swift in Sources */,
 				72ED25C328978EBE00031AD1 /* SignInViewController.swift in Sources */,
 				D371D2172923D5A000E28231 /* Protocol.swift in Sources */,
+				72758D2D295ACF9D00BDFF9C /* EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift in Sources */,
 				72AAC6E629574D4300FAD71D /* TokenAuthenticator.swift in Sources */,
 				72512A80292CDFC40003F431 /* CreatingStudyScheduleContentViewController.swift in Sources */,
 				72E2BED5291CD50C009BCCB7 /* EditingStudyFormViewController.swift in Sources */,
@@ -636,14 +665,16 @@
 				72F7CFA828F832D100E0D0C0 /* CalendarViewController.swift in Sources */,
 				D3F2C6ED28B1207700CEC549 /* MailCheckViewController.swift in Sources */,
 				7299969028C5BA510008A1C1 /* StudyGeneralRuleAttendanceTableViewController.swift in Sources */,
+				72758D29295ACF1F00BDFF9C /* EditingStudyGeneralRuleAttendanceCollectionViewCell.swift in Sources */,
 				D3DD808B29268A8F001250CF /* ValidationNumberCheckingPopViewController.swift in Sources */,
 				72ED25AA2897788900031AD1 /* SceneDelegate.swift in Sources */,
 				D3BF053428BE39CA00AF7D3B /* ByeViewController.swift in Sources */,
 				724DDD8929421B6000AC0B61 /* EditingStudySchduleViewController.swift in Sources */,
+				72758D2F295ACFB000BDFF9C /* EditingStudyGeneralRuleAttendanceFineTableViewCell.swift in Sources */,
 				D306E6D1292BA78300F9BE5C /* AttendanceBottomViewController.swift in Sources */,
 				D398B46E28B5E14E00598B03 /* SettingAlertTableViewCell.swift in Sources */,
 				7299968428B09B110008A1C1 /* AnnouncementViewController.swift in Sources */,
-				D3BF054328C0E9EC00AF7D3B /* StudyGeneralRuleViewController.swift in Sources */,
+				D3BF054328C0E9EC00AF7D3B /* CreatingStudyGeneralRuleViewController.swift in Sources */,
 				721D8A4728A39F4C00829A2B /* CreatingStudyFormViewController.swift in Sources */,
 				72E2BF09292769DE009BCCB7 /* AttendanceTableViewCells.swift in Sources */,
 				D398B47428B7AEAF00598B03 /* TreatingPersonalDataViewController.swift in Sources */,
@@ -657,6 +688,7 @@
 				D3F0983E2914E25100D1E55F /* UBottomSheet.swift in Sources */,
 				726FA4632901A352004E49A9 /* ScheduleTableView.swift in Sources */,
 				D3D8D1BA29291E0B00B9D6B6 /* AttendanceModificationCollectionViewCell.swift in Sources */,
+				72758D2B295ACF5600BDFF9C /* EditingExcommunicationRuleCollectionViewCell.swift in Sources */,
 				7282F18228FFE7D2003EF100 /* ToDoCollectionViewCell.swift in Sources */,
 				D314A1DB2905190100093C0E /* Extension.swift in Sources */,
 				72E2BF0B292B7428009BCCB7 /* AttendanceView.swift in Sources */,

--- a/STUDYA/STUDYA/Base.lproj/Main.storyboard
+++ b/STUDYA/STUDYA/Base.lproj/Main.storyboard
@@ -852,6 +852,7 @@
                         <outlet property="studyCategoryBackgroundView" destination="IpP-ze-5Dr" id="lOj-cA-KvN"/>
                         <outlet property="studyCategoryLabel" destination="80m-4k-0rj" id="5Kh-Ws-4el"/>
                         <outlet property="studyExitButton" destination="ZI6-tY-Jf4" id="dHb-p1-Rw9"/>
+                        <outlet property="studyGeneralRuleBackgroundView" destination="qF8-Jp-ZZN" id="q3v-vG-vab"/>
                         <outlet property="studyInfoBackgroundView" destination="6nj-Mo-asz" id="DJ9-8h-HML"/>
                         <outlet property="studyIntroductionLabel" destination="2la-1O-YGC" id="Z9J-lr-1Vd"/>
                         <outlet property="studyNameLabel" destination="NB9-Dx-EeZ" id="af3-Nl-J0J"/>
@@ -867,14 +868,14 @@
         <scene sceneID="sEv-bZ-cz2">
             <objects>
                 <tableViewController storyboardIdentifier="StudyGeneralRuleAttendanceTableViewController" id="6jG-nN-6fk" customClass="StudyGeneralRuleAttendanceTableViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" dataMode="static" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="Wdc-NJ-3EV">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" dataMode="static" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="Wdc-NJ-3EV">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
                             <tableViewSection id="Red-cD-z36">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="X2O-rf-J5Q">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="0.0" id="X2O-rf-J5Q">
                                         <rect key="frame" x="0.0" y="50" width="414" height="196.66667175292969"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X2O-rf-J5Q" id="nzx-Cq-bab">
@@ -968,13 +969,13 @@
                                                 <constraint firstAttribute="trailing" secondItem="th6-33-xBD" secondAttribute="trailing" constant="58" id="ymC-zg-vCY"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        <inset key="separatorInset" minX="15" minY="0.0" maxX="0.0" maxY="0.0"/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection id="o8K-Ic-PCW">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="QrZ-yl-jHr">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="0.0" id="QrZ-yl-jHr">
                                         <rect key="frame" x="0.0" y="324.66667175292969" width="414" height="218"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QrZ-yl-jHr" id="yty-bf-7ze">
@@ -1097,7 +1098,7 @@
                             </tableViewSection>
                             <tableViewSection id="4ES-sm-tzr">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="P9V-7V-xlw">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="0.0" id="P9V-7V-xlw">
                                         <rect key="frame" x="0.0" y="620.66667175292969" width="414" height="284.33334350585938"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="P9V-7V-xlw" id="WEo-2L-yYd">

--- a/STUDYA/STUDYA/Base.lproj/Main.storyboard
+++ b/STUDYA/STUDYA/Base.lproj/Main.storyboard
@@ -25,10 +25,10 @@
             </objects>
             <point key="canvasLocation" x="139" y="125"/>
         </scene>
-        <!--Study General Rule View Controller-->
+        <!--Creating Study General Rule View Controller-->
         <scene sceneID="Cja-RO-R89">
             <objects>
-                <viewController storyboardIdentifier="StudyGeneralRuleViewController" id="LRo-Cd-Chu" customClass="StudyGeneralRuleViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CreatingStudyGeneralRuleViewController" id="LRo-Cd-Chu" customClass="CreatingStudyGeneralRuleViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="MvQ-e3-8Ut">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -157,321 +157,10 @@
             </objects>
             <point key="canvasLocation" x="969.60000000000002" y="116.00985221674877"/>
         </scene>
-        <!--Study General Rule Attendance Table View Controller-->
-        <scene sceneID="OlK-3U-R84">
-            <objects>
-                <tableViewController storyboardIdentifier="StudyGeneralRuleAttendanceTableViewController" id="dhe-LV-ocZ" customClass="StudyGeneralRuleAttendanceTableViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" dataMode="static" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="ISI-9j-asv">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <sections>
-                            <tableViewSection id="Gmk-oG-xM2">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Q2e-NU-HHt">
-                                        <rect key="frame" x="0.0" y="50" width="414" height="200"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Q2e-NU-HHt" id="IiS-rL-ODt">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="출결 규칙" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PuJ-n1-eH7">
-                                                    <rect key="frame" x="27.000000000000004" y="18" width="59.333333333333343" height="20"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" name="ppsBlack"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="* 결석 조건을 입력하지 않으면 스터디가 끝나는 시간으로 설정돼요." textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cja-rl-pBz">
-                                                    <rect key="frame" x="27" y="43" width="344" height="14.333333333333336"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" name="ppsGray1"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="스터디 시작 후" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xp3-4b-maX">
-                                                    <rect key="frame" x="39" y="83.333333333333329" width="97" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="스터디 시작 후" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2qT-yB-LW6">
-                                                    <rect key="frame" x="39" y="147" width="97" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분 부터" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yfx-7B-g6B">
-                                                    <rect key="frame" x="276" y="84.333333333333329" width="46" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분 부터" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l2a-Tm-WHE">
-                                                    <rect key="frame" x="276" y="148" width="46" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="결석" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pCd-h1-Ldw">
-                                                    <rect key="frame" x="326" y="147" width="30" height="21"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MlF-JN-FxP" customClass="RoundedNumberField" customModule="STUDYA" customModuleProvider="target">
-                                                    <rect key="frame" x="146" y="85" width="120" height="18"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L07-KW-jej" customClass="RoundedNumberField" customModule="STUDYA" customModuleProvider="target">
-                                                    <rect key="frame" x="146" y="148.33333333333334" width="120" height="18.333333333333343"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지각" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="260-tr-5He">
-                                                    <rect key="frame" x="326" y="83.333333333333329" width="30" height="21"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="l2a-Tm-WHE" firstAttribute="bottom" secondItem="pCd-h1-Ldw" secondAttribute="bottom" id="1cK-rw-ja7"/>
-                                                <constraint firstItem="L07-KW-jej" firstAttribute="leading" secondItem="2qT-yB-LW6" secondAttribute="trailing" constant="10" id="1nc-Es-j9s"/>
-                                                <constraint firstItem="2qT-yB-LW6" firstAttribute="top" secondItem="Xp3-4b-maX" secondAttribute="bottom" constant="42.666666666666671" id="3Bh-ce-ZjJ"/>
-                                                <constraint firstItem="L07-KW-jej" firstAttribute="centerY" secondItem="2qT-yB-LW6" secondAttribute="centerY" id="3om-o1-zMd"/>
-                                                <constraint firstItem="Yfx-7B-g6B" firstAttribute="leading" secondItem="MlF-JN-FxP" secondAttribute="trailing" constant="10" id="4OL-BZ-b29"/>
-                                                <constraint firstItem="260-tr-5He" firstAttribute="bottom" secondItem="Yfx-7B-g6B" secondAttribute="bottom" id="7wT-Zp-f7c"/>
-                                                <constraint firstAttribute="bottom" secondItem="2qT-yB-LW6" secondAttribute="bottom" constant="32" id="FUH-vO-LlG"/>
-                                                <constraint firstItem="pCd-h1-Ldw" firstAttribute="leading" secondItem="l2a-Tm-WHE" secondAttribute="trailing" constant="4" id="Jtk-eU-DWm"/>
-                                                <constraint firstItem="260-tr-5He" firstAttribute="leading" secondItem="Yfx-7B-g6B" secondAttribute="trailing" constant="4" id="MWj-mq-FPR"/>
-                                                <constraint firstItem="MlF-JN-FxP" firstAttribute="leading" secondItem="Xp3-4b-maX" secondAttribute="trailing" constant="10" id="Q8D-Hy-h5R"/>
-                                                <constraint firstItem="2qT-yB-LW6" firstAttribute="leading" secondItem="Xp3-4b-maX" secondAttribute="leading" id="S2J-BV-55B"/>
-                                                <constraint firstItem="PuJ-n1-eH7" firstAttribute="leading" secondItem="IiS-rL-ODt" secondAttribute="leading" constant="27.000000000000004" id="UNN-UA-oPA"/>
-                                                <constraint firstItem="Cja-rl-pBz" firstAttribute="leading" secondItem="PuJ-n1-eH7" secondAttribute="leading" id="YN8-4C-anT"/>
-                                                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="PuJ-n1-eH7" secondAttribute="trailing" constant="200" id="ZWh-eM-RJD"/>
-                                                <constraint firstAttribute="trailing" secondItem="260-tr-5He" secondAttribute="trailing" constant="58" id="bl1-IN-fD9"/>
-                                                <constraint firstItem="l2a-Tm-WHE" firstAttribute="leading" secondItem="L07-KW-jej" secondAttribute="trailing" constant="10" id="box-Xt-Ztc"/>
-                                                <constraint firstItem="Xp3-4b-maX" firstAttribute="leading" secondItem="IiS-rL-ODt" secondAttribute="leading" constant="39" id="cGo-G8-WZ3"/>
-                                                <constraint firstItem="Yfx-7B-g6B" firstAttribute="bottom" secondItem="Xp3-4b-maX" secondAttribute="bottom" id="glG-l9-2hZ"/>
-                                                <constraint firstItem="l2a-Tm-WHE" firstAttribute="bottom" secondItem="2qT-yB-LW6" secondAttribute="bottom" id="jp8-P8-EpE"/>
-                                                <constraint firstItem="Xp3-4b-maX" firstAttribute="top" secondItem="Cja-rl-pBz" secondAttribute="bottom" constant="26" id="m4X-z1-PJo"/>
-                                                <constraint firstAttribute="trailing" secondItem="pCd-h1-Ldw" secondAttribute="trailing" constant="58" id="s2G-PJ-17q"/>
-                                                <constraint firstItem="MlF-JN-FxP" firstAttribute="centerY" secondItem="Xp3-4b-maX" secondAttribute="centerY" id="stz-6e-Aok"/>
-                                                <constraint firstItem="PuJ-n1-eH7" firstAttribute="top" secondItem="IiS-rL-ODt" secondAttribute="top" constant="18" id="tDm-sZ-sc4"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Cja-rl-pBz" secondAttribute="trailing" constant="23" id="v6y-wm-rlD"/>
-                                                <constraint firstItem="Cja-rl-pBz" firstAttribute="top" secondItem="PuJ-n1-eH7" secondAttribute="bottom" constant="5" id="zRx-kj-tbt"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection id="XH3-bG-viW">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="6af-HE-Yfe">
-                                        <rect key="frame" x="0.0" y="328" width="414" height="218"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6af-HE-Yfe" id="vAc-zg-zvL">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="218"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="벌금 규칙" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UO0-f0-Wpk">
-                                                    <rect key="frame" x="27" y="16" width="60" height="20"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" name="ppsBlack"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="* 출석체크 시, 입력하신 규칙에 따라 벌금이 자동으로 계산돼요." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xVS-MV-Zk8">
-                                                    <rect key="frame" x="27" y="41" width="299.66666666666669" height="14.333333333333336"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" name="ppsGray1"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지각" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t2r-ZI-VAb">
-                                                    <rect key="frame" x="33" y="67.333333333333329" width="28" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zgT-vA-U2D">
-                                                    <rect key="frame" x="105" y="92.666666666666671" width="28" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GmX-md-Pdz">
-                                                    <rect key="frame" x="373" y="92.666666666666671" width="14" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vBw-49-F5F">
-                                                    <rect key="frame" x="373" y="166" width="14" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bdD-I3-EGL" customClass="RoundedNumberField" customModule="STUDYA" customModuleProvider="target">
-                                                    <rect key="frame" x="28" y="90.333333333333329" width="75" height="18.666666666666671"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="75" id="xFJ-Sm-afM"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="b8g-Nu-XAz">
-                                                    <rect key="frame" x="195" y="78.666666666666671" width="175" height="42"/>
-                                                    <color key="backgroundColor" name="background"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="175" id="ZPO-U2-UKH"/>
-                                                        <constraint firstAttribute="height" constant="42" id="z79-au-59e"/>
-                                                    </constraints>
-                                                    <color key="textColor" name="ppsGray1"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="x7E-3e-ASz">
-                                                    <rect key="frame" x="27" y="152" width="344" height="42"/>
-                                                    <color key="backgroundColor" name="background"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="42" id="gPA-ej-8vb"/>
-                                                    </constraints>
-                                                    <color key="textColor" name="ppsGray1"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="결석 1회당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lz2-WZ-A1p">
-                                                    <rect key="frame" x="33" y="129" width="67" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T6s-nZ-Rqf">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="218"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="t2r-ZI-VAb" firstAttribute="leading" secondItem="vAc-zg-zvL" secondAttribute="leading" constant="33" id="0pu-9U-D5f"/>
-                                                <constraint firstItem="xVS-MV-Zk8" firstAttribute="leading" secondItem="UO0-f0-Wpk" secondAttribute="leading" id="1yq-W4-az4"/>
-                                                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="Lz2-WZ-A1p" secondAttribute="trailing" constant="200" id="2fP-Li-tPe"/>
-                                                <constraint firstItem="zgT-vA-U2D" firstAttribute="leading" secondItem="bdD-I3-EGL" secondAttribute="trailing" constant="2" id="30x-pA-R5T"/>
-                                                <constraint firstAttribute="bottom" secondItem="T6s-nZ-Rqf" secondAttribute="bottom" id="3dQ-wr-4cR"/>
-                                                <constraint firstAttribute="bottom" secondItem="x7E-3e-ASz" secondAttribute="bottom" constant="24" id="9MG-dw-o4G"/>
-                                                <constraint firstItem="Lz2-WZ-A1p" firstAttribute="leading" secondItem="vAc-zg-zvL" secondAttribute="leading" constant="33" id="Ba7-Qq-ncq"/>
-                                                <constraint firstItem="zgT-vA-U2D" firstAttribute="centerY" secondItem="bdD-I3-EGL" secondAttribute="centerY" constant="3" id="CXt-J2-bAT"/>
-                                                <constraint firstItem="bdD-I3-EGL" firstAttribute="leading" secondItem="vAc-zg-zvL" secondAttribute="leading" constant="28" id="Co3-Eh-LqO"/>
-                                                <constraint firstItem="x7E-3e-ASz" firstAttribute="leading" secondItem="vAc-zg-zvL" secondAttribute="leading" constant="27" id="Kji-gv-gjT"/>
-                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="t2r-ZI-VAb" secondAttribute="trailing" constant="353" id="LcD-QY-YQb"/>
-                                                <constraint firstItem="GmX-md-Pdz" firstAttribute="leading" secondItem="b8g-Nu-XAz" secondAttribute="trailing" constant="3" id="VMh-ay-GsE"/>
-                                                <constraint firstItem="b8g-Nu-XAz" firstAttribute="centerY" secondItem="zgT-vA-U2D" secondAttribute="centerY" constant="-3" id="VS7-Mm-nPA"/>
-                                                <constraint firstItem="xVS-MV-Zk8" firstAttribute="top" secondItem="UO0-f0-Wpk" secondAttribute="bottom" constant="5" id="aBZ-V7-Dem"/>
-                                                <constraint firstItem="bdD-I3-EGL" firstAttribute="top" secondItem="t2r-ZI-VAb" secondAttribute="bottom" constant="3" id="aVm-R4-1HU"/>
-                                                <constraint firstItem="UO0-f0-Wpk" firstAttribute="leading" secondItem="vAc-zg-zvL" secondAttribute="leading" constant="27" id="fFl-Ln-Eab"/>
-                                                <constraint firstAttribute="trailing" secondItem="vBw-49-F5F" secondAttribute="trailing" constant="27" id="gf9-ho-lY1"/>
-                                                <constraint firstItem="T6s-nZ-Rqf" firstAttribute="leading" secondItem="vAc-zg-zvL" secondAttribute="leading" id="gij-OD-XUJ"/>
-                                                <constraint firstItem="vBw-49-F5F" firstAttribute="centerY" secondItem="x7E-3e-ASz" secondAttribute="centerY" constant="3" id="iRu-Is-GJ7"/>
-                                                <constraint firstItem="Lz2-WZ-A1p" firstAttribute="top" secondItem="bdD-I3-EGL" secondAttribute="bottom" constant="20" id="ibb-iD-5cZ"/>
-                                                <constraint firstItem="x7E-3e-ASz" firstAttribute="top" secondItem="Lz2-WZ-A1p" secondAttribute="bottom" constant="3" id="ji7-O5-6Ff"/>
-                                                <constraint firstItem="t2r-ZI-VAb" firstAttribute="top" secondItem="xVS-MV-Zk8" secondAttribute="bottom" constant="12" id="kDV-AJ-wRb"/>
-                                                <constraint firstItem="T6s-nZ-Rqf" firstAttribute="top" secondItem="vAc-zg-zvL" secondAttribute="top" id="nAO-dz-DQY"/>
-                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="UO0-f0-Wpk" secondAttribute="trailing" constant="327" id="oNB-kl-VSD"/>
-                                                <constraint firstItem="UO0-f0-Wpk" firstAttribute="top" secondItem="vAc-zg-zvL" secondAttribute="top" constant="16" id="pvO-Ua-zm0"/>
-                                                <constraint firstAttribute="trailing" secondItem="GmX-md-Pdz" secondAttribute="trailing" constant="27" id="qwv-ku-lpT"/>
-                                                <constraint firstItem="b8g-Nu-XAz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="zgT-vA-U2D" secondAttribute="trailing" constant="2" id="svP-mG-79r"/>
-                                                <constraint firstItem="GmX-md-Pdz" firstAttribute="centerY" secondItem="b8g-Nu-XAz" secondAttribute="centerY" constant="3" id="v3H-91-Da1"/>
-                                                <constraint firstAttribute="trailing" secondItem="T6s-nZ-Rqf" secondAttribute="trailing" id="vbM-m6-uga"/>
-                                                <constraint firstItem="vBw-49-F5F" firstAttribute="leading" secondItem="x7E-3e-ASz" secondAttribute="trailing" constant="2" id="viX-ok-Rwh"/>
-                                                <constraint firstAttribute="trailingMargin" relation="lessThanOrEqual" secondItem="xVS-MV-Zk8" secondAttribute="trailing" constant="67.5" id="zFB-7z-ORO"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection id="15T-S7-gJD">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zvL-Qd-9ie">
-                                        <rect key="frame" x="0.0" y="624" width="414" height="284.33334350585938"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zvL-Qd-9ie" id="0g3-NW-mt0">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="284.33334350585938"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="보증금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kpf-kU-eo4">
-                                                    <rect key="frame" x="27" y="15.999999999999998" width="42" height="19.333333333333329"/>
-                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" name="ppsBlack"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oQK-jE-t5H">
-                                                    <rect key="frame" x="373" y="56.333333333333343" width="14" height="20"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SaT-PR-QyN">
-                                                    <rect key="frame" x="27" y="42.333333333333336" width="344" height="42.000000000000007"/>
-                                                    <color key="backgroundColor" name="background"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="42" id="UuL-sU-hgj"/>
-                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="344" id="l7G-cX-dXm"/>
-                                                    </constraints>
-                                                    <color key="textColor" name="ppsGray1"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <textInputTraits key="textInputTraits"/>
-                                                </textField>
-                                                <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PLu-Hi-clw">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="284.33333333333331"/>
-                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="PLu-Hi-clw" firstAttribute="top" secondItem="0g3-NW-mt0" secondAttribute="top" id="5fN-VN-ydE"/>
-                                                <constraint firstItem="kpf-kU-eo4" firstAttribute="leading" secondItem="0g3-NW-mt0" secondAttribute="leading" constant="27" id="7yF-hg-Czl"/>
-                                                <constraint firstAttribute="bottom" secondItem="PLu-Hi-clw" secondAttribute="bottom" id="Hza-DE-trZ"/>
-                                                <constraint firstItem="oQK-jE-t5H" firstAttribute="centerY" secondItem="SaT-PR-QyN" secondAttribute="centerY" constant="3" id="JzX-Ra-hNL"/>
-                                                <constraint firstItem="kpf-kU-eo4" firstAttribute="top" secondItem="0g3-NW-mt0" secondAttribute="top" constant="16" id="OQ2-yG-hf0"/>
-                                                <constraint firstItem="SaT-PR-QyN" firstAttribute="top" secondItem="kpf-kU-eo4" secondAttribute="bottom" constant="7" id="QI2-ep-G0G"/>
-                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="kpf-kU-eo4" secondAttribute="trailing" constant="345" id="QmY-Be-gUQ"/>
-                                                <constraint firstItem="PLu-Hi-clw" firstAttribute="leading" secondItem="0g3-NW-mt0" secondAttribute="leading" id="Z22-Bz-0T2"/>
-                                                <constraint firstAttribute="trailing" secondItem="PLu-Hi-clw" secondAttribute="trailing" id="Zui-Gl-6bu"/>
-                                                <constraint firstItem="SaT-PR-QyN" firstAttribute="leading" secondItem="0g3-NW-mt0" secondAttribute="leading" constant="27" id="b7B-Rr-ToC"/>
-                                                <constraint firstAttribute="trailing" secondItem="oQK-jE-t5H" secondAttribute="trailing" constant="27" id="bbo-ha-EEe"/>
-                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="SaT-PR-QyN" secondAttribute="bottom" constant="200" id="iQy-y3-U7B"/>
-                                                <constraint firstItem="oQK-jE-t5H" firstAttribute="leading" secondItem="SaT-PR-QyN" secondAttribute="trailing" constant="2" id="nok-2m-DDU"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                        </sections>
-                        <connections>
-                            <outlet property="dataSource" destination="dhe-LV-ocZ" id="bgl-e2-364"/>
-                            <outlet property="delegate" destination="dhe-LV-ocZ" id="CUL-6v-pkH"/>
-                        </connections>
-                    </tableView>
-                    <size key="freeformSize" width="414" height="896"/>
-                    <connections>
-                        <outlet property="absenceFineTextField" destination="x7E-3e-ASz" id="SF6-GX-9I7"/>
-                        <outlet property="absenceRuleTimeField" destination="L07-KW-jej" id="hDZ-T6-C70"/>
-                        <outlet property="depositDimmingView" destination="PLu-Hi-clw" id="y5r-wF-xWo"/>
-                        <outlet property="depositTextField" destination="SaT-PR-QyN" id="6ZJ-Wq-l9B"/>
-                        <outlet property="fineDimmingView" destination="T6s-nZ-Rqf" id="yRd-c5-Qse"/>
-                        <outlet property="latenessFineTextField" destination="b8g-Nu-XAz" id="NAQ-oy-7dE"/>
-                        <outlet property="latenessRuleTimeField" destination="MlF-JN-FxP" id="LNo-us-dcf"/>
-                        <outlet property="perLateMinuteField" destination="bdD-I3-EGL" id="zjl-Ot-kcU"/>
-                    </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Crc-IM-fQz" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1920" y="116"/>
-        </scene>
-        <!--Study Free Rule View Controller-->
+        <!--Creating Study Free Rule View Controller-->
         <scene sceneID="RWJ-5d-CSQ">
             <objects>
-                <viewController storyboardIdentifier="StudyFreeRuleViewController" id="cSp-IO-dlv" customClass="StudyFreeRuleViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CreatingStudyFreeRuleViewController" id="cSp-IO-dlv" customClass="CreatingStudyFreeRuleViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="pV6-cG-2S7">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -550,7 +239,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1MD-5A-7sA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2782" y="137"/>
+            <point key="canvasLocation" x="2770" y="112"/>
         </scene>
         <!--Study Info View Controller-->
         <scene sceneID="SVq-jJ-f4h">
@@ -1173,6 +862,401 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="d8J-0N-Hz9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3728" y="151"/>
+        </scene>
+        <!--Study General Rule Attendance Table View Controller-->
+        <scene sceneID="sEv-bZ-cz2">
+            <objects>
+                <tableViewController storyboardIdentifier="StudyGeneralRuleAttendanceTableViewController" id="6jG-nN-6fk" customClass="StudyGeneralRuleAttendanceTableViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" dataMode="static" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="Wdc-NJ-3EV">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <sections>
+                            <tableViewSection id="Red-cD-z36">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="X2O-rf-J5Q">
+                                        <rect key="frame" x="0.0" y="50" width="414" height="196.66667175292969"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X2O-rf-J5Q" id="nzx-Cq-bab">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="196.66667175292969"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="출결 규칙" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4iG-7y-fNq">
+                                                    <rect key="frame" x="27.000000000000004" y="18" width="59.333333333333343" height="20"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                    <color key="textColor" name="ppsBlack"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="* 결석 조건을 입력하지 않으면 스터디가 끝나는 시간으로 설정돼요." textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cM9-EQ-hV7">
+                                                    <rect key="frame" x="27" y="43" width="344" height="14.333333333333336"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" name="ppsGray1"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="스터디 시작 후" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ufs-J8-Fxi">
+                                                    <rect key="frame" x="39.000000000000007" y="83.333333333333329" width="91.666666666666686" height="19.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="스터디 시작 후" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WZg-jn-Svg">
+                                                    <rect key="frame" x="39.000000000000007" y="145.33333333333334" width="91.666666666666686" height="19.333333333333343"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분 부터" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tfj-vp-Qoa">
+                                                    <rect key="frame" x="276" y="82.666666666666671" width="46" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분 부터" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sLb-sn-M9a">
+                                                    <rect key="frame" x="276" y="144.66666666666666" width="46" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="결석" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N7Y-QS-VfR">
+                                                    <rect key="frame" x="326" y="143.66666666666666" width="30" height="21"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CqY-xb-rzZ" customClass="RoundedNumberField" customModule="STUDYA" customModuleProvider="target">
+                                                    <rect key="frame" x="140.66666666666666" y="84" width="125.33333333333334" height="18"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="c1G-CA-Kb8" customClass="RoundedNumberField" customModule="STUDYA" customModuleProvider="target">
+                                                    <rect key="frame" x="140.66666666666666" y="146" width="125.33333333333334" height="18.333333333333343"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지각" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="th6-33-xBD">
+                                                    <rect key="frame" x="326" y="81.666666666666671" width="30" height="21"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="th6-33-xBD" firstAttribute="bottom" secondItem="tfj-vp-Qoa" secondAttribute="bottom" id="0yH-5f-f6c"/>
+                                                <constraint firstItem="cM9-EQ-hV7" firstAttribute="top" secondItem="4iG-7y-fNq" secondAttribute="bottom" constant="5" id="7Uc-q5-Gjz"/>
+                                                <constraint firstItem="Ufs-J8-Fxi" firstAttribute="top" secondItem="cM9-EQ-hV7" secondAttribute="bottom" constant="26" id="9vd-Ks-AqW"/>
+                                                <constraint firstItem="tfj-vp-Qoa" firstAttribute="bottom" secondItem="Ufs-J8-Fxi" secondAttribute="bottom" id="AWW-4f-Hed"/>
+                                                <constraint firstAttribute="bottom" secondItem="WZg-jn-Svg" secondAttribute="bottom" constant="32" id="DOb-PM-r6t"/>
+                                                <constraint firstItem="4iG-7y-fNq" firstAttribute="leading" secondItem="nzx-Cq-bab" secondAttribute="leading" constant="27.000000000000004" id="GHw-xp-6Ff"/>
+                                                <constraint firstItem="CqY-xb-rzZ" firstAttribute="centerY" secondItem="Ufs-J8-Fxi" secondAttribute="centerY" id="KPu-Ky-LO1"/>
+                                                <constraint firstItem="cM9-EQ-hV7" firstAttribute="leading" secondItem="4iG-7y-fNq" secondAttribute="leading" id="Vjc-Ki-X4M"/>
+                                                <constraint firstItem="CqY-xb-rzZ" firstAttribute="leading" secondItem="Ufs-J8-Fxi" secondAttribute="trailing" constant="10" id="XOy-aJ-CX5"/>
+                                                <constraint firstItem="WZg-jn-Svg" firstAttribute="leading" secondItem="Ufs-J8-Fxi" secondAttribute="leading" id="a05-mf-Zdb"/>
+                                                <constraint firstItem="Ufs-J8-Fxi" firstAttribute="leading" secondItem="nzx-Cq-bab" secondAttribute="leading" constant="39" id="bfv-6S-Psr"/>
+                                                <constraint firstItem="4iG-7y-fNq" firstAttribute="top" secondItem="nzx-Cq-bab" secondAttribute="top" constant="18" id="dgS-gc-AwH"/>
+                                                <constraint firstItem="c1G-CA-Kb8" firstAttribute="leading" secondItem="WZg-jn-Svg" secondAttribute="trailing" constant="10" id="eEk-u7-nlI"/>
+                                                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="4iG-7y-fNq" secondAttribute="trailing" constant="200" id="eOF-lT-fcY"/>
+                                                <constraint firstItem="c1G-CA-Kb8" firstAttribute="centerY" secondItem="WZg-jn-Svg" secondAttribute="centerY" id="en1-cM-vBU"/>
+                                                <constraint firstItem="WZg-jn-Svg" firstAttribute="top" secondItem="Ufs-J8-Fxi" secondAttribute="bottom" constant="42.666666666666671" id="fNe-fj-lTh"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="cM9-EQ-hV7" secondAttribute="trailing" constant="23" id="gsO-Mk-YsU"/>
+                                                <constraint firstItem="N7Y-QS-VfR" firstAttribute="leading" secondItem="sLb-sn-M9a" secondAttribute="trailing" constant="4" id="gwY-Yh-J9z"/>
+                                                <constraint firstItem="sLb-sn-M9a" firstAttribute="bottom" secondItem="N7Y-QS-VfR" secondAttribute="bottom" id="kkX-vq-f0S"/>
+                                                <constraint firstItem="sLb-sn-M9a" firstAttribute="bottom" secondItem="WZg-jn-Svg" secondAttribute="bottom" id="ko0-Cw-9lM"/>
+                                                <constraint firstItem="th6-33-xBD" firstAttribute="leading" secondItem="tfj-vp-Qoa" secondAttribute="trailing" constant="4" id="n4D-fL-hPh"/>
+                                                <constraint firstAttribute="trailing" secondItem="N7Y-QS-VfR" secondAttribute="trailing" constant="58" id="on5-Ck-bvj"/>
+                                                <constraint firstItem="tfj-vp-Qoa" firstAttribute="leading" secondItem="CqY-xb-rzZ" secondAttribute="trailing" constant="10" id="paJ-NF-a1d"/>
+                                                <constraint firstItem="sLb-sn-M9a" firstAttribute="leading" secondItem="c1G-CA-Kb8" secondAttribute="trailing" constant="10" id="ujP-kC-nW9"/>
+                                                <constraint firstAttribute="trailing" secondItem="th6-33-xBD" secondAttribute="trailing" constant="58" id="ymC-zg-vCY"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="o8K-Ic-PCW">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="QrZ-yl-jHr">
+                                        <rect key="frame" x="0.0" y="324.66667175292969" width="414" height="218"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QrZ-yl-jHr" id="yty-bf-7ze">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="218"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="벌금 규칙" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gzR-hq-Ks9">
+                                                    <rect key="frame" x="27" y="16" width="60" height="20"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                    <color key="textColor" name="ppsBlack"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="* 출석체크 시, 입력하신 규칙에 따라 벌금이 자동으로 계산돼요." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6sI-cc-i3p">
+                                                    <rect key="frame" x="27" y="41" width="299.66666666666669" height="14.333333333333336"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" name="ppsGray1"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="지각" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nj5-ce-nqG">
+                                                    <rect key="frame" x="33" y="67.333333333333329" width="28" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="분당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hlm-Xw-Vz7">
+                                                    <rect key="frame" x="105" y="92.666666666666671" width="28" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cZV-dJ-YOi">
+                                                    <rect key="frame" x="373" y="92.666666666666671" width="14" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FV4-Mz-Rym">
+                                                    <rect key="frame" x="373" y="166" width="14" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="hpY-ih-1MR" customClass="RoundedNumberField" customModule="STUDYA" customModuleProvider="target">
+                                                    <rect key="frame" x="28" y="90.333333333333329" width="75" height="18.666666666666671"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="75" id="rnx-m2-r7U"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GC9-9R-C6O">
+                                                    <rect key="frame" x="195" y="78.666666666666671" width="175" height="42"/>
+                                                    <color key="backgroundColor" name="background"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="42" id="nzd-gW-Bzr"/>
+                                                        <constraint firstAttribute="width" constant="175" id="q5c-xq-tEG"/>
+                                                    </constraints>
+                                                    <color key="textColor" name="ppsGray1"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yDM-07-c9o">
+                                                    <rect key="frame" x="27" y="152" width="344" height="42"/>
+                                                    <color key="backgroundColor" name="background"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="42" id="ilU-ku-aS6"/>
+                                                    </constraints>
+                                                    <color key="textColor" name="ppsGray1"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="결석 1회당" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gx5-jv-nx6">
+                                                    <rect key="frame" x="33" y="129" width="67" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h44-Tq-4oi">
+                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="218"/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="yDM-07-c9o" firstAttribute="top" secondItem="gx5-jv-nx6" secondAttribute="bottom" constant="3" id="0gu-9R-vCQ"/>
+                                                <constraint firstItem="hpY-ih-1MR" firstAttribute="leading" secondItem="yty-bf-7ze" secondAttribute="leading" constant="28" id="1OV-mp-hSt"/>
+                                                <constraint firstItem="Nj5-ce-nqG" firstAttribute="leading" secondItem="yty-bf-7ze" secondAttribute="leading" constant="33" id="1vx-1K-S9G"/>
+                                                <constraint firstItem="Nj5-ce-nqG" firstAttribute="top" secondItem="6sI-cc-i3p" secondAttribute="bottom" constant="12" id="2JP-dz-KSf"/>
+                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gzR-hq-Ks9" secondAttribute="trailing" constant="327" id="3Az-Sv-XEU"/>
+                                                <constraint firstItem="hpY-ih-1MR" firstAttribute="top" secondItem="Nj5-ce-nqG" secondAttribute="bottom" constant="3" id="4wh-Ck-7CJ"/>
+                                                <constraint firstItem="GC9-9R-C6O" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hlm-Xw-Vz7" secondAttribute="trailing" constant="2" id="56Q-W7-NNi"/>
+                                                <constraint firstItem="hlm-Xw-Vz7" firstAttribute="centerY" secondItem="hpY-ih-1MR" secondAttribute="centerY" constant="3" id="5vg-3L-feE"/>
+                                                <constraint firstItem="h44-Tq-4oi" firstAttribute="leading" secondItem="yty-bf-7ze" secondAttribute="leading" id="6lI-Vf-sAu"/>
+                                                <constraint firstAttribute="trailing" secondItem="cZV-dJ-YOi" secondAttribute="trailing" constant="27" id="8Si-Qg-Opd"/>
+                                                <constraint firstItem="gzR-hq-Ks9" firstAttribute="top" secondItem="yty-bf-7ze" secondAttribute="top" constant="16" id="AtQ-g8-HL1"/>
+                                                <constraint firstItem="FV4-Mz-Rym" firstAttribute="leading" secondItem="yDM-07-c9o" secondAttribute="trailing" constant="2" id="K3b-aJ-NB3"/>
+                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Nj5-ce-nqG" secondAttribute="trailing" constant="353" id="KTZ-0a-QGu"/>
+                                                <constraint firstAttribute="trailing" secondItem="h44-Tq-4oi" secondAttribute="trailing" id="NOw-FK-nHd"/>
+                                                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="gx5-jv-nx6" secondAttribute="trailing" constant="200" id="Ny3-TV-B70"/>
+                                                <constraint firstItem="cZV-dJ-YOi" firstAttribute="leading" secondItem="GC9-9R-C6O" secondAttribute="trailing" constant="3" id="PUA-t9-Qpl"/>
+                                                <constraint firstItem="FV4-Mz-Rym" firstAttribute="centerY" secondItem="yDM-07-c9o" secondAttribute="centerY" constant="3" id="QqZ-pC-ZBx"/>
+                                                <constraint firstItem="6sI-cc-i3p" firstAttribute="top" secondItem="gzR-hq-Ks9" secondAttribute="bottom" constant="5" id="Vav-Yl-i43"/>
+                                                <constraint firstItem="GC9-9R-C6O" firstAttribute="centerY" secondItem="hlm-Xw-Vz7" secondAttribute="centerY" constant="-3" id="Y9a-VL-gsf"/>
+                                                <constraint firstAttribute="trailingMargin" relation="lessThanOrEqual" secondItem="6sI-cc-i3p" secondAttribute="trailing" constant="67.5" id="YZ5-2G-6Du"/>
+                                                <constraint firstAttribute="bottom" secondItem="h44-Tq-4oi" secondAttribute="bottom" id="aRV-eE-L7s"/>
+                                                <constraint firstItem="cZV-dJ-YOi" firstAttribute="centerY" secondItem="GC9-9R-C6O" secondAttribute="centerY" constant="3" id="dly-1m-ewX"/>
+                                                <constraint firstItem="6sI-cc-i3p" firstAttribute="leading" secondItem="gzR-hq-Ks9" secondAttribute="leading" id="frU-CH-frd"/>
+                                                <constraint firstItem="yDM-07-c9o" firstAttribute="leading" secondItem="yty-bf-7ze" secondAttribute="leading" constant="27" id="gRp-1F-bTp"/>
+                                                <constraint firstItem="h44-Tq-4oi" firstAttribute="top" secondItem="yty-bf-7ze" secondAttribute="top" id="kyk-yr-ZTr"/>
+                                                <constraint firstAttribute="trailing" secondItem="FV4-Mz-Rym" secondAttribute="trailing" constant="27" id="lAS-m0-nlS"/>
+                                                <constraint firstItem="gx5-jv-nx6" firstAttribute="leading" secondItem="yty-bf-7ze" secondAttribute="leading" constant="33" id="lOB-PP-4eD"/>
+                                                <constraint firstItem="gzR-hq-Ks9" firstAttribute="leading" secondItem="yty-bf-7ze" secondAttribute="leading" constant="27" id="moX-ec-NDV"/>
+                                                <constraint firstAttribute="bottom" secondItem="yDM-07-c9o" secondAttribute="bottom" constant="24" id="udB-oy-UDT"/>
+                                                <constraint firstItem="hlm-Xw-Vz7" firstAttribute="leading" secondItem="hpY-ih-1MR" secondAttribute="trailing" constant="2" id="wA6-Cj-4sk"/>
+                                                <constraint firstItem="gx5-jv-nx6" firstAttribute="top" secondItem="hpY-ih-1MR" secondAttribute="bottom" constant="20" id="yxO-G8-o5Y"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="4ES-sm-tzr">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="P9V-7V-xlw">
+                                        <rect key="frame" x="0.0" y="620.66667175292969" width="414" height="284.33334350585938"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="P9V-7V-xlw" id="WEo-2L-yYd">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="284.33334350585938"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="보증금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CHo-AG-iZS">
+                                                    <rect key="frame" x="27" y="15.999999999999998" width="42" height="19.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                    <color key="textColor" name="ppsBlack"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CSK-qT-FdB">
+                                                    <rect key="frame" x="373" y="56.333333333333343" width="14" height="20"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bMf-hE-eVk">
+                                                    <rect key="frame" x="27" y="42.333333333333336" width="344" height="42.000000000000007"/>
+                                                    <color key="backgroundColor" name="background"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="344" id="4P1-w1-8HK"/>
+                                                        <constraint firstAttribute="height" constant="42" id="NOA-ot-cUT"/>
+                                                    </constraints>
+                                                    <color key="textColor" name="ppsGray1"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                                <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PEF-4Q-2zY">
+                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="284.33333333333331"/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="bMf-hE-eVk" firstAttribute="top" secondItem="CHo-AG-iZS" secondAttribute="bottom" constant="7" id="2jF-9B-4yV"/>
+                                                <constraint firstAttribute="bottom" secondItem="PEF-4Q-2zY" secondAttribute="bottom" id="5Dk-JD-8Qz"/>
+                                                <constraint firstItem="CHo-AG-iZS" firstAttribute="leading" secondItem="WEo-2L-yYd" secondAttribute="leading" constant="27" id="BJ6-ZZ-fCu"/>
+                                                <constraint firstItem="PEF-4Q-2zY" firstAttribute="leading" secondItem="WEo-2L-yYd" secondAttribute="leading" id="BMp-4f-Ha8"/>
+                                                <constraint firstAttribute="trailing" secondItem="CSK-qT-FdB" secondAttribute="trailing" constant="27" id="N7m-C2-sRQ"/>
+                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="CHo-AG-iZS" secondAttribute="trailing" constant="345" id="UCD-vw-GVa"/>
+                                                <constraint firstItem="CSK-qT-FdB" firstAttribute="leading" secondItem="bMf-hE-eVk" secondAttribute="trailing" constant="2" id="VW6-ES-TSb"/>
+                                                <constraint firstItem="CSK-qT-FdB" firstAttribute="centerY" secondItem="bMf-hE-eVk" secondAttribute="centerY" constant="3" id="Yqg-y6-abd"/>
+                                                <constraint firstAttribute="trailing" secondItem="PEF-4Q-2zY" secondAttribute="trailing" id="aA9-Qy-XZZ"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bMf-hE-eVk" secondAttribute="bottom" constant="200" id="doo-uo-OiT"/>
+                                                <constraint firstItem="bMf-hE-eVk" firstAttribute="leading" secondItem="WEo-2L-yYd" secondAttribute="leading" constant="27" id="iEl-Fy-inM"/>
+                                                <constraint firstItem="CHo-AG-iZS" firstAttribute="top" secondItem="WEo-2L-yYd" secondAttribute="top" constant="16" id="q86-yc-xff"/>
+                                                <constraint firstItem="PEF-4Q-2zY" firstAttribute="top" secondItem="WEo-2L-yYd" secondAttribute="top" id="yQf-b1-Tkm"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="6jG-nN-6fk" id="XAq-ia-PNQ"/>
+                            <outlet property="delegate" destination="6jG-nN-6fk" id="jXx-Rg-Ihs"/>
+                        </connections>
+                    </tableView>
+                    <size key="freeformSize" width="414" height="896"/>
+                    <connections>
+                        <outlet property="absenceFineTextField" destination="yDM-07-c9o" id="s7q-0s-1sf"/>
+                        <outlet property="absenceRuleTimeField" destination="c1G-CA-Kb8" id="COw-uM-nFh"/>
+                        <outlet property="depositDimmingView" destination="PEF-4Q-2zY" id="qSt-WL-P4m"/>
+                        <outlet property="depositTextField" destination="bMf-hE-eVk" id="SxQ-cE-0Lx"/>
+                        <outlet property="fineDimmingView" destination="h44-Tq-4oi" id="Crv-o1-RiS"/>
+                        <outlet property="latenessFineTextField" destination="GC9-9R-C6O" id="7Qs-PH-fbn"/>
+                        <outlet property="latenessRuleTimeField" destination="CqY-xb-rzZ" id="VDi-7M-0Rv"/>
+                        <outlet property="perLateMinuteField" destination="hpY-ih-1MR" id="vgL-fI-LNI"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8lC-LK-Hsg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1920" y="116"/>
+        </scene>
+        <!--Editing Study Free Rule View Controller-->
+        <scene sceneID="UMZ-Ks-ePo">
+            <objects>
+                <viewController storyboardIdentifier="EditingStudyFreeRuleViewController" id="LGU-7m-LHP" customClass="EditingStudyFreeRuleViewController" customModule="STUDYA" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="jvX-A8-K44">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lQ1-Tw-EBF">
+                                <rect key="frame" x="17" y="77" width="380" height="160"/>
+                                <subviews>
+                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6r1-82-ihE">
+                                        <rect key="frame" x="20" y="20" width="340" height="120"/>
+                                        <color key="backgroundColor" name="background"/>
+                                        <color key="textColor" name="ppsBlack"/>
+                                        <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="16"/>
+                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="rect" keyPath="textContainerInset">
+                                                <rect key="value" x="0.0" y="0.0" width="0.0" height="0.0"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </textView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="진행방식을 입력해주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fYR-Fj-kaF">
+                                        <rect key="frame" x="20" y="20" width="161" height="20"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                        <color key="textColor" name="ppsGray2"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" name="background"/>
+                                <constraints>
+                                    <constraint firstItem="6r1-82-ihE" firstAttribute="top" secondItem="lQ1-Tw-EBF" secondAttribute="top" constant="20" id="5Sx-KX-Cry"/>
+                                    <constraint firstItem="6r1-82-ihE" firstAttribute="leading" secondItem="lQ1-Tw-EBF" secondAttribute="leading" constant="20" id="DE9-mp-AIk"/>
+                                    <constraint firstAttribute="trailing" secondItem="6r1-82-ihE" secondAttribute="trailing" constant="20" id="UBf-U8-DZr"/>
+                                    <constraint firstItem="fYR-Fj-kaF" firstAttribute="leading" secondItem="6r1-82-ihE" secondAttribute="leading" id="Y9v-Du-xD5"/>
+                                    <constraint firstAttribute="height" constant="160" id="a9w-Oi-67r"/>
+                                    <constraint firstItem="fYR-Fj-kaF" firstAttribute="top" secondItem="6r1-82-ihE" secondAttribute="top" id="ej2-Qb-TNr"/>
+                                    <constraint firstAttribute="bottom" secondItem="6r1-82-ihE" secondAttribute="bottom" constant="20" id="lrq-Dg-I7y"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="24"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="clipsToBounds" value="YES"/>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bm6-fi-Riu">
+                                <rect key="frame" x="17" y="247" width="380" height="129"/>
+                                <string key="text">* 예상 진행 기간은 어느 정도인가요?
+* 스터디 커리큘럼은 무엇인가요?
+* 어떤 방식으로 진행하나요? 
+   (발표, 토론 문제풀이 등)
+* 참여자는 무엇을 준비해와야 하나요?
+* 교재나 준비물이 있나요?
+* 회비가 있나요?
+* 소통/기록은 어떤 방식으로 하나요? 
+   ★링크 첨부 가능</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" name="ppsGray1"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="EmG-ut-syj"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="bm6-fi-Riu" firstAttribute="top" secondItem="lQ1-Tw-EBF" secondAttribute="bottom" constant="10" id="3P0-md-SXx"/>
+                            <constraint firstItem="lQ1-Tw-EBF" firstAttribute="leading" secondItem="EmG-ut-syj" secondAttribute="leading" constant="17" id="8qe-gZ-4jx"/>
+                            <constraint firstItem="lQ1-Tw-EBF" firstAttribute="top" secondItem="EmG-ut-syj" secondAttribute="top" constant="30" id="OO9-Bi-xCh"/>
+                            <constraint firstItem="EmG-ut-syj" firstAttribute="trailing" secondItem="lQ1-Tw-EBF" secondAttribute="trailing" constant="17" id="Xak-T7-qle"/>
+                            <constraint firstItem="EmG-ut-syj" firstAttribute="trailing" secondItem="bm6-fi-Riu" secondAttribute="trailing" constant="17" id="nGE-4U-UWj"/>
+                            <constraint firstItem="bm6-fi-Riu" firstAttribute="leading" secondItem="EmG-ut-syj" secondAttribute="leading" constant="17" id="nnl-tF-TDY"/>
+                        </constraints>
+                    </view>
+                    <size key="freeformSize" width="414" height="896"/>
+                    <connections>
+                        <outlet property="freeRuletextView" destination="6r1-82-ihE" id="AoI-sQ-XDx"/>
+                        <outlet property="placeholderLabel" destination="fYR-Fj-kaF" id="UHD-JQ-L8v"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="07g-YJ-QLK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2770" y="947"/>
         </scene>
     </scenes>
     <resources>

--- a/STUDYA/STUDYA/Component.swift
+++ b/STUDYA/STUDYA/Component.swift
@@ -468,6 +468,7 @@ class CustomTextField: UITextField {
 }
 
 class CustomLabel: UILabel {
+    
     // MARK: - Initialize
     
     init(title: String, tintColor: AssetColor, size: CGFloat, isBold: Bool = false, isNecessaryTitle: Bool = false) {
@@ -480,8 +481,8 @@ class CustomLabel: UILabel {
         configure(title: title, isNecessaryTitle: isNecessaryTitle)
     }
     
-    convenience init(title: String, boldPart: String) {
-        self.init(title: title, tintColor: .ppsBlack, size: 16)
+    convenience init(title: String, boldPart: String, tintColor: AssetColor = .ppsBlack, size: CGFloat = 16) {
+        self.init(title: title, tintColor: tintColor, size: size)
         
         let fontSize = self.font.pointSize
         let font = UIFont.boldSystemFont(ofSize: fontSize)
@@ -921,6 +922,7 @@ final class RoundedNumberField: UITextField, UITextFieldDelegate, UIPickerViewDe
     }()
     
     var isNecessaryField = false
+    var isHavePicker = false
     
     private lazy var picker = UIPickerView()
     
@@ -937,6 +939,8 @@ final class RoundedNumberField: UITextField, UITextFieldDelegate, UIPickerViewDe
         } else {
             text = "--"
         }
+        
+        isHavePicker = isPicker
         
         if isPicker {
             setPicker()
@@ -1018,32 +1022,44 @@ final class RoundedNumberField: UITextField, UITextFieldDelegate, UIPickerViewDe
     }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        
-        let currentText = NSString(string: textField.text ?? "")
-        let finalText = currentText.replacingCharacters(in: range, with: string)
-        
-        guard finalText.count <= 2 else { return false }
-        
-        let utf8Char = string.cString(using: .utf8)
-        let isBackSpace = strcmp(utf8Char, "\\b")
-        
-        if string.checkOnlyNumbers() || isBackSpace == -92 { return true }
-        
-        return false
+        if !isNecessaryField {
+            let currentText = NSString(string: textField.text ?? "")
+            let finalText = currentText.replacingCharacters(in: range, with: string)
+            
+            guard finalText.count <= 2 else { return false }
+            
+            let utf8Char = string.cString(using: .utf8)
+            let isBackSpace = strcmp(utf8Char, "\\b")
+            
+            if string.checkOnlyNumbers() || isBackSpace == -92 { return true }
+            
+            return false
+        } else {
+            return true
+        }
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        print("🇨🇦")
-        if textField.text == "--" {
-            text = ""
+        if isHavePicker {
+            let row = strArray.firstIndex(of: textField.text ?? "--") ?? 0
+            picker.selectRow(row, inComponent: 0, animated: false)
+        } else {
+            self.text = Formatter.formatIntoNoneDecimal(textField.text)?.toString()
         }
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
+        
         if let text = textField.text, let intText = Int(text) {
             self.text = Formatter.formatIntoDecimal(number: intText)
+        } else if let text = textField.text, text != "0" {
+            return
         } else {
-            self.text = "--"
+            if isHavePicker {
+                self.text = "--"
+            } else {
+                self.text = "0"
+            }
         }
     }
     

--- a/STUDYA/STUDYA/Component.swift
+++ b/STUDYA/STUDYA/Component.swift
@@ -1045,7 +1045,7 @@ final class RoundedNumberField: UITextField, UITextFieldDelegate, UIPickerViewDe
         }
     }
     
-    func textFieldDidBeginEditing(_ textField: UITextField) {
+    func pickerSelectRowMatchedTextIn(_ textField: UITextField) {
         if isHavePicker {
             let row = strArray.firstIndex(of: textField.text ?? "--") ?? 0
             picker.selectRow(row, inComponent: 0, animated: false)
@@ -1054,11 +1054,15 @@ final class RoundedNumberField: UITextField, UITextFieldDelegate, UIPickerViewDe
         }
     }
     
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        pickerSelectRowMatchedTextIn(textField)
+    }
+    
     func textFieldDidEndEditing(_ textField: UITextField) {
         
         if let text = textField.text, let intText = Int(text) {
             self.text = Formatter.formatIntoDecimal(number: intText)
-        } else if let text = textField.text, text != "0" {
+        } else if let text = textField.text, text != "", text != "0", text != "--" {
             return
         } else {
             if isHavePicker {

--- a/STUDYA/STUDYA/CreatingStudyFreeRuleViewController.swift
+++ b/STUDYA/STUDYA/CreatingStudyFreeRuleViewController.swift
@@ -1,5 +1,5 @@
 //
-//  StudyFreeRuleViewController.swift
+//  CreatingStudyFreeRuleViewController.swift
 //  STUDYA
 //
 //  Created by 서동운 on 2022/09/02.
@@ -9,7 +9,7 @@
 import UIKit
 import SnapKit
 
-class StudyFreeRuleViewController: UIViewController {
+class CreatingStudyFreeRuleViewController: UIViewController {
 
     // MARK: - Properties
     
@@ -80,7 +80,7 @@ class StudyFreeRuleViewController: UIViewController {
 
 // MARK: - UITextViewDelegate
 
-extension StudyFreeRuleViewController: UITextViewDelegate {
+extension CreatingStudyFreeRuleViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         placeholderLabel.isHidden = true
     }

--- a/STUDYA/STUDYA/CreatingStudyGeneralRuleViewController.swift
+++ b/STUDYA/STUDYA/CreatingStudyGeneralRuleViewController.swift
@@ -1,5 +1,5 @@
 //
-//  StudyGeneralRuleViewController.swift
+//  CreatingStudyGeneralRuleViewController.swift
 //  STUDYA
 //
 //  Created by 신동훈 on 2022/09/01.
@@ -15,13 +15,13 @@ struct GeneralStudyRuleViewModel {
         return generalRule.lateness
     }
     var absence: Absence {
-        return generalRule.absence ?? Absence(time: nil, fine: nil)
+        return generalRule.absence
     }
     var deposit: Int? {
         return generalRule.deposit
     }
     var excommunication: Excommunication {
-        return generalRule.excommunication ?? Excommunication(lateness: nil, absence: nil)
+        return generalRule.excommunication
     }
     
     init() {
@@ -42,18 +42,17 @@ struct GeneralStudyRuleViewModel {
 //        isfieldsenabled에 따라 혹시모를 moneyrelatedfields의 필드의 값을 다 삭제시켜주는 작업 해줘야하나?
     }
     
-    func configure(cell: ExcommunicationRuleCollectionViewCell) {
+    func configure(cell: CreatingExcommunicationRuleCollectionViewCell) {
         cell.lateNumberField.text = excommunication.lateness == nil ? "--" : String(excommunication.lateness!)
         cell.absenceNumberField.text = excommunication.absence == nil ? "--" : String(excommunication.absence!)
     }
 }
 
-final class StudyGeneralRuleViewController: UIViewController {
+final class CreatingStudyGeneralRuleViewController: UIViewController {
     
     var doneButtonDidTapped: (GeneralStudyRule) -> () = { generalRule in }
     var viewDidUpdated: (UICollectionView) -> () = { collectionView in }
     var generalRuleViewModel = GeneralStudyRuleViewModel()
-    var task: Task?
     
     @IBOutlet weak var leftLabel: UILabel!
     @IBOutlet weak var rightLabel: UILabel!
@@ -65,7 +64,7 @@ final class StudyGeneralRuleViewController: UIViewController {
     @IBOutlet weak var rightCenterXConstraint: NSLayoutConstraint!
     
     private let vc =  UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "StudyGeneralRuleAttendanceTableViewController") as! StudyGeneralRuleAttendanceTableViewController
-    private lazy var excommunicationCell = collectionView.dequeueReusableCell(withReuseIdentifier: ExcommunicationRuleCollectionViewCell.identifier, for: IndexPath(item: 1, section: 0)) as! ExcommunicationRuleCollectionViewCell
+    private lazy var excommunicationCell = collectionView.dequeueReusableCell(withReuseIdentifier: CreatingExcommunicationRuleCollectionViewCell.identifier, for: IndexPath(item: 1, section: 0)) as! CreatingExcommunicationRuleCollectionViewCell
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -76,14 +75,8 @@ final class StudyGeneralRuleViewController: UIViewController {
         collectionView.dataSource = self
         collectionView.isScrollEnabled = false
         
-        if task == .editing {
-            doneButton.isHidden = true
-        } else if task == .creating {
-            doneButton.isHidden = false
-        }
-        
-        collectionView.register(AttendanceRuleCollectionViewCell.self, forCellWithReuseIdentifier: AttendanceRuleCollectionViewCell.identifier)
-        collectionView.register(ExcommunicationRuleCollectionViewCell.self, forCellWithReuseIdentifier: ExcommunicationRuleCollectionViewCell.identifier)
+        collectionView.register(CreatingStudyGeneralRuleAttendanceCollectionViewCell.self, forCellWithReuseIdentifier: CreatingStudyGeneralRuleAttendanceCollectionViewCell.identifier)
+        collectionView.register(CreatingExcommunicationRuleCollectionViewCell.self, forCellWithReuseIdentifier: CreatingExcommunicationRuleCollectionViewCell.identifier)
         
         let layout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
         layout.scrollDirection = .horizontal
@@ -142,7 +135,7 @@ final class StudyGeneralRuleViewController: UIViewController {
     }
 }
 
-extension StudyGeneralRuleViewController: UICollectionViewDataSource {
+extension CreatingStudyGeneralRuleViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         2
     }
@@ -150,7 +143,7 @@ extension StudyGeneralRuleViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.item {
         case 0:
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AttendanceRuleCollectionViewCell.identifier, for: indexPath) as! AttendanceRuleCollectionViewCell
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CreatingStudyGeneralRuleAttendanceCollectionViewCell.identifier, for: indexPath) as! CreatingStudyGeneralRuleAttendanceCollectionViewCell
             
             cell.addSubview(vc.view)
             vc.view.snp.makeConstraints { make in
@@ -173,7 +166,7 @@ extension StudyGeneralRuleViewController: UICollectionViewDataSource {
     }
 }
 
-extension StudyGeneralRuleViewController: UICollectionViewDelegateFlowLayout {
+extension CreatingStudyGeneralRuleViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return collectionView.frame.size
     }

--- a/STUDYA/STUDYA/CreatingStudyRuleViewController.swift
+++ b/STUDYA/STUDYA/CreatingStudyRuleViewController.swift
@@ -126,8 +126,8 @@ class CreatingStudyRuleViewController: UIViewController {
     @objc private func generalRuleViewTapped() {
         
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        let studyGeneralRuleVC  = storyboard.instantiateViewController(withIdentifier: "StudyGeneralRuleViewController") as! StudyGeneralRuleViewController
-        studyGeneralRuleVC.task = .creating
+        let studyGeneralRuleVC  = storyboard.instantiateViewController(withIdentifier: "CreatingStudyGeneralRuleViewController") as! CreatingStudyGeneralRuleViewController
+
         studyGeneralRuleVC.generalRuleViewModel.generalRule = creatingStudyRuleViewModel.study.generalRule ?? GeneralStudyRule(lateness: Lateness(), absence: Absence(), deposit: nil, excommunication: Excommunication())
         studyGeneralRuleVC.doneButtonDidTapped = { rule in
             self.creatingStudyRuleViewModel.study.generalRule = rule
@@ -146,7 +146,7 @@ class CreatingStudyRuleViewController: UIViewController {
     
     @objc private func freeRuleViewTapped() {
         
-        let studyFreeRuleVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "StudyFreeRuleViewController") as! StudyFreeRuleViewController
+        let studyFreeRuleVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "CreatingStudyFreeRuleViewController") as! CreatingStudyFreeRuleViewController
         
         studyFreeRuleVC.viewDidUpdated = { textView in
             textView.text = self.creatingStudyRuleViewModel.study.freeRule
@@ -173,7 +173,7 @@ class CreatingStudyRuleViewController: UIViewController {
         
         Network.shared.createStudy(study) { result in
             switch result {
-            case .success(let study):
+            case .success(_):
                 
                 let nextVC = CreatingStudyCompleteViewController()
                 self.navigationController?.pushViewController(nextVC, animated: true)

--- a/STUDYA/STUDYA/CreatingStudyScheduleContentViewController.swift
+++ b/STUDYA/STUDYA/CreatingStudyScheduleContentViewController.swift
@@ -66,7 +66,7 @@ class CreatingStudyScheduleContentViewController: UIViewController {
     
     // MARK: - Actions
     
-    @objc private  func closeButtonDidTapped() {
+    @objc private func closeButtonDidTapped() {
         self.dismiss(animated: true)
     }
     

--- a/STUDYA/STUDYA/CustomAF.swift
+++ b/STUDYA/STUDYA/CustomAF.swift
@@ -58,6 +58,7 @@ enum RequestPurpose: Requestable {
     case updateScheduleStatus(ID)  //22
     case updateSchedule(ID)    //23
     case updateStudySchedule(StudySchedule)
+    case endStudy(ID)
     
     //    HTTPMethod: DELETE
     case deleteUser(UserID) ////10
@@ -126,6 +127,7 @@ extension RequestPurpose {
             return "/user"
         case .updateStudy(let studyID, _):
             return "/study/\(studyID)"
+
             
         case .updateAnnouncement:
             return "/noti"
@@ -137,6 +139,9 @@ extension RequestPurpose {
             return "/user/schedule"
         case  .updateStudySchedule:
             return "/study/schedule" //domb: gitbook에서 studyschedule id를 바디로 줄게 아니라 path에 넣어주어야하는건 아닌지.
+            
+        case .endStudy(let studyID):
+            return "/study/end/\(studyID)"
             
             //    HTTPMethod: DEL
         case .deleteUser(let id):
@@ -178,7 +183,7 @@ extension RequestPurpose {
         switch self {
         case .signUp, .emailCheck, .signIn, .refreshToken, .createStudy, .joinStudy, .createAnnouncement, .createSchedule, .createStudySchedule: return .post
             
-        case .updateUser, .updateStudy, .updateAnnouncement, .updatePinnedAnnouncement, .updateScheduleStatus, .updateSchedule, .updateStudySchedule: return .put
+        case .updateUser, .updateStudy, .updateAnnouncement, .updatePinnedAnnouncement, .updateScheduleStatus, .updateSchedule, .updateStudySchedule, .endStudy: return .put
             
         case .deleteUser, .deleteAnnouncement, .deleteStudySchedule: return .delete
             

--- a/STUDYA/STUDYA/EditingExcommunicationRuleCollectionViewCell.swift
+++ b/STUDYA/STUDYA/EditingExcommunicationRuleCollectionViewCell.swift
@@ -1,0 +1,110 @@
+//
+//  EditingExcommunicationRuleCollectionViewCell.swift
+//  STUDYA
+//
+//  Created by 서동운 on 12/27/22.
+//
+
+import UIKit
+
+class EditingExcommunicationRuleCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier = "EditingExcommunicationRuleCollectionViewCell"
+    
+    private let excommunicationTitleLabel = CustomLabel(title: "강퇴 조건", tintColor: .ppsBlack, size: 16, isBold: true)
+    private let excommunicationDescriptionLabel = CustomLabel(title: "* 멤버가 강퇴 조건에 도달하면 관리자에게 알림이 전송돼요.\n* 지각과 결석 조건을 모두 입력하면, 둘 중 하나만 만족해도 강퇴 조건에 도달해요.", tintColor: .ppsGray1, size: 12)
+    internal let latenessCountField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false)
+    private let latenessCountFieldBehindLabel = CustomLabel(title: "번 지각 시", boldPart: "지각")
+    internal let absenceCountField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false)
+    private let absenceCountFieldBehindLabel = CustomLabel(title: "번 결석 시", boldPart: "결석")
+    
+    var latenessCountFieldAction: (Int?) -> Void = { latenessCount in }
+    var absenceCountFieldAction: (Int?) -> Void = { absenceCount in }
+    
+    // MARK: - Initialization
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        latenessCountField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        absenceCountField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        
+        configureViews()
+        setConstaints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    // MARK: - Actions
+    
+    @objc func roundedNumberFieldDidChanged(_ sender: RoundedNumberField) {
+        switch sender {
+        case latenessCountField:
+            latenessCountFieldAction(sender.text?.toInt())
+        case absenceCountField:
+            absenceCountFieldAction(sender.text?.toInt())
+        default:
+            return
+        }
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.endEditing(true)
+    }
+    
+    // MARK: - Configure
+    
+    func configureViews() {
+        backgroundColor = .systemBackground
+        
+        contentView.addSubview(excommunicationTitleLabel)
+        contentView.addSubview(excommunicationDescriptionLabel)
+
+        contentView.addSubview(latenessCountField)
+        contentView.addSubview(latenessCountFieldBehindLabel)
+        contentView.addSubview(absenceCountField)
+        contentView.addSubview(absenceCountFieldBehindLabel)
+        
+    }
+    // MARK: - Setting Constraints
+    
+    func setConstaints() {
+        
+        excommunicationTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(contentView.safeAreaLayoutGuide).inset(17)
+            make.leading.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        
+        excommunicationDescriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(excommunicationTitleLabel.snp.bottom)
+            .offset(5)
+            make.leading.equalTo(excommunicationTitleLabel)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        
+        latenessCountField.snp.makeConstraints { make in
+            make.top.equalTo(excommunicationDescriptionLabel.snp.bottom).offset(12)
+            make.leading.equalTo(excommunicationDescriptionLabel)
+        }
+        
+        latenessCountFieldBehindLabel.snp.makeConstraints { make in
+            make.leading.equalTo(latenessCountField.snp.trailing).offset(10)
+            make.centerY.equalTo(latenessCountField)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+            make.width.equalTo(70)
+        }
+        absenceCountField.snp.makeConstraints { make in
+            make.top.equalTo(latenessCountField.snp.bottom).offset(13)
+            make.leading.equalTo(latenessCountField)
+        }
+        absenceCountFieldBehindLabel.snp.makeConstraints { make in
+            make.leading.equalTo(absenceCountField.snp.trailing).offset(10)
+            make.centerY.equalTo(absenceCountField)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+            make.width.equalTo(70)
+        }
+    }
+}

--- a/STUDYA/STUDYA/EditingStudyFormViewController.swift
+++ b/STUDYA/STUDYA/EditingStudyFormViewController.swift
@@ -165,8 +165,15 @@ final class EditingStudyFormViewController: UIViewController {
         
         switch sender {
             case doneButton:
-                print("수정 완료")
-                self.dismiss(animated: true)
+            guard let study = studyViewModel?.study, let studyID = study.id else { return }
+            Network.shared.updateStudy(study, id: studyID) { result in
+                switch result {
+                case .success(let _):
+                    self.dismiss(animated: true)
+                case .failure(let failure):
+                    print(failure)
+                }
+            }
             case  cancelButton:
                 print("수정 취소")
                 self.dismiss(animated: true)
@@ -175,7 +182,7 @@ final class EditingStudyFormViewController: UIViewController {
         }
     }
     
-    @objc func onKeyboardAppear(_ notification: NSNotification) {
+    @objc func keyboardAppear(_ notification: NSNotification) {
         
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         
@@ -202,7 +209,7 @@ final class EditingStudyFormViewController: UIViewController {
         }
     }
     
-    @objc func onKeyboardDisappear(_ notification: NSNotification) {
+    @objc func keyboardDisappear(_ notification: NSNotification) {
         
         scrollView.contentInset = UIEdgeInsets.zero
         self.view.endEditing(true)
@@ -210,7 +217,7 @@ final class EditingStudyFormViewController: UIViewController {
     
     private func enableTapGesture() {
         
-        let singleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(onKeyboardDisappear))
+        let singleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(keyboardDisappear))
         
         singleTapGestureRecognizer.numberOfTapsRequired = 1
         singleTapGestureRecognizer.isEnabled = true
@@ -295,7 +302,7 @@ final class EditingStudyFormViewController: UIViewController {
     
     private func addNotification() {
         
-        NotificationCenter.default.addObserver(self, selector: #selector(onKeyboardAppear(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAppear(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         token = NotificationCenter.default.addObserver(forName: .categoryDidChange, object: nil, queue: .main) { [self] noti in
             guard let cellInfo = noti.object as? [String: Any] else { return }
             let title = cellInfo["title"] as! String

--- a/STUDYA/STUDYA/EditingStudyFormViewController.swift
+++ b/STUDYA/STUDYA/EditingStudyFormViewController.swift
@@ -13,8 +13,9 @@ final class EditingStudyFormViewController: UIViewController {
     
     var studyViewModel: StudyViewModel? {
         didSet {
-            guard let study = studyViewModel?.study else { return }
-            bind(study)
+            guard let studyViewModel = studyViewModel else { return }
+            bind(studyViewModel.study)
+            doneButton.isEnabled = studyViewModel.formIsValid
         }
     }
    

--- a/STUDYA/STUDYA/EditingStudyFreeRuleViewController.swift
+++ b/STUDYA/STUDYA/EditingStudyFreeRuleViewController.swift
@@ -1,0 +1,86 @@
+//
+//  EditingStudyFreeRuleViewController.swift
+//  STUDYA
+//
+//  Created by 서동운 on 2022/12/27.
+//
+// 스터디 만들기 - 스터디 진행방식
+
+import UIKit
+import SnapKit
+
+class EditingStudyFreeRuleViewController: UIViewController {
+
+    // MARK: - Properties
+    
+    var study: Study?
+    
+    @IBOutlet weak var freeRuletextView: UITextView!
+    @IBOutlet weak var placeholderLabel: UILabel!
+    
+    // MARK: - Life Cycle
+  
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        freeRuletextView.delegate = self
+        
+        self.navigationItem.title = "진행방식"
+        
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(ruleEditDone))
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .done, target: self, action: #selector(cancel))
+        self.navigationItem.rightBarButtonItem?.tintColor = .appColor(.cancel)
+        self.navigationItem.leftBarButtonItem?.tintColor = .appColor(.cancel)
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        freeRuletextView.text = study?.freeRule
+        placeholderLabel.isHidden = study?.freeRule == nil ? false : true
+    }
+    // MARK: - Configure
+    
+    // MARK: - Actions
+    
+    @objc func ruleEditDone() {
+        
+        guard let study = study else { return }
+        guard let studyID = study.id else { return }
+        Network.shared.updateStudy(study, id: studyID) { result in
+            switch result {
+            case .success(let success):
+                print(success)
+                self.dismiss(animated: true)
+            case .failure(let failure):
+                print(failure)
+            }
+        }
+    }
+    
+    @objc func cancel() {
+        
+        self.dismiss(animated: true)
+    }
+    
+    // MARK: - Setting Constraints
+}
+
+// MARK: - UITextViewDelegate
+
+extension EditingStudyFreeRuleViewController: UITextViewDelegate {
+    
+    func textViewDidChange(_ textView: UITextView) {
+        study?.freeRule = textView.text
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        placeholderLabel.isHidden = true
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text == "" {
+            placeholderLabel.isHidden = false
+        }
+    }
+}

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceCollectionViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceCollectionViewCell.swift
@@ -1,0 +1,172 @@
+//
+//  EditingStudyGeneralRuleAttendanceCollectionViewCell.swift
+//  STUDYA
+//
+//  Created by 서동운 on 12/27/22.
+//
+
+import UIKit
+
+class EditingStudyGeneralRuleAttendanceCollectionViewCell: UICollectionViewCell {
+    
+    // MARK: - Properties
+  
+    static let identifier = "EditingStudyGeneralRuleAttendanceCollectionViewCell"
+    
+    weak var delegate: EditingStudyGeneralRuleViewController?
+    
+    private var generalRuleAttendanceTableView = GeneralRuleAttendanceTableView()
+    private var keyboardHeight: CGFloat = 0
+    // MARK: - Initialization
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setNotification()
+        enableTapGesture()
+        
+        generalRuleAttendanceTableView.dataSource = self
+        generalRuleAttendanceTableView.delegate = self
+        configureViews()
+        setConstaints()
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Actions
+    
+    @objc func keyboardAppear(_ notification: NSNotification) {
+        
+        guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
+        
+        let keyboardSize = keyboardFrame.cgRectValue
+        keyboardHeight = keyboardSize.height
+        
+        let inset = UIEdgeInsets(top: 0, left: 0, bottom: keyboardHeight, right: 0)
+
+        generalRuleAttendanceTableView.contentInset = inset
+    }
+    
+    @objc func keyboardDisappear(_ notification: NSNotification) {
+        generalRuleAttendanceTableView.endEditing(true)
+        generalRuleAttendanceTableView.contentInset = .zero
+    }
+    
+    private func enableTapGesture() {
+        
+        let singleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(keyboardDisappear))
+        
+        singleTapGestureRecognizer.numberOfTapsRequired = 1
+        singleTapGestureRecognizer.isEnabled = true
+        singleTapGestureRecognizer.cancelsTouchesInView = false
+        
+        contentView.addGestureRecognizer(singleTapGestureRecognizer)
+    }
+
+    private func setNotification() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAppear(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDisappear(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    // MARK: - Configure
+    
+    private func configureViews() {
+        contentView.addSubview(generalRuleAttendanceTableView)
+    }
+    // MARK: - Setting Constraints
+    
+    private func setConstaints() {
+        generalRuleAttendanceTableView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalTo(contentView.safeAreaLayoutGuide)
+            make.bottom.equalTo(contentView)
+        }
+    }
+}
+
+extension EditingStudyGeneralRuleAttendanceCollectionViewCell: UITableViewDataSource, UITableViewDelegate {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 3
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.section {
+        case 0:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditingStudyGeneralRuleAttendanceTimeTableViewCell.identifier, for: indexPath) as? EditingStudyGeneralRuleAttendanceTimeTableViewCell else { return UITableViewCell() }
+        
+            cell.latenessRuleTimeField.text = delegate?.study?.generalRule?.lateness.time?.toString() ?? "--"
+            cell.absenceRuleTimeField.text = delegate?.study?.generalRule?.absence.time?.toString()
+            ?? "--"
+            cell.latenessRuleTimeFieldAction = { [self] latenessRuleTime in
+                delegate?.study?.generalRule?.lateness.time = latenessRuleTime
+            }
+            cell.absenceRuleTimeFieldAction = { [self] absenceRuleTime in
+                delegate?.study?.generalRule?.absence.time = absenceRuleTime
+            }
+            
+            return cell
+        case 1:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditingStudyGeneralRuleAttendanceFineTableViewCell.identifier, for: indexPath) as? EditingStudyGeneralRuleAttendanceFineTableViewCell else { return UITableViewCell() }
+            
+            cell.perLateMinuteField.text = delegate?.study?.generalRule?.lateness.count?.toString()
+            ?? "--"
+            cell.latenessFineField.text = Formatter.formatIntoDecimal(number: delegate?.study?.generalRule?.lateness.fine ?? 0)
+            cell.absenceFineField.text = Formatter.formatIntoDecimal(number: delegate?.study?.generalRule?.absence.fine ?? 0)
+            
+            cell.perLateMinuteFieldAction = { [self] perLateMinute in
+                delegate?.study?.generalRule?.lateness.count = perLateMinute
+            }
+            cell.latenessFineFieldAction = { [self] latenessFine in
+                delegate?.study?.generalRule?.lateness.fine = latenessFine
+            }
+            cell.absenceFineFieldAction = { [self] absenceFine in
+                delegate?.study?.generalRule?.absence.fine = absenceFine
+            }
+            
+            return cell
+        case 2:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditingStudyGeneralRuleDepositTableViewCell.identifier, for: indexPath) as? EditingStudyGeneralRuleDepositTableViewCell else { return UITableViewCell() }
+            
+            cell.depositTextField.text = Formatter.formatIntoDecimal(number: delegate?.study?.generalRule?.deposit ?? 0)
+            
+            cell.depositTextFieldAction = { [self] deposit in
+                delegate?.study?.generalRule?.deposit = deposit
+            }
+            
+            return cell
+        default:
+            return UITableViewCell()
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        if section == 0 || section == 1 {
+            return UIView()
+        } else {
+            return nil
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if section == 0 || section == 1 {
+            return 10
+        } else {
+            return 0
+        }
+    }
+}

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceFineTableViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceFineTableViewCell.swift
@@ -27,19 +27,18 @@ class EditingStudyGeneralRuleAttendanceFineTableViewCell: UITableViewCell {
     let latenessFineField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: true)
     let absenceFineField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: true)
     
-    /// 디밍처리
-    lazy var fineDimmingView = UIView()
-    
     var perLateMinuteFieldAction: (Int?) -> Void = { perLateMinute in }
     var latenessFineFieldAction: (Int?) -> Void = { latenessFine in }
     var absenceFineFieldAction: (Int?) -> Void = { absenceFine in }
+    
+    lazy var fineDimmingView = UIView(backgroundColor: .white, alpha: 0.5)
 
     // MARK: - Initialization
    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        perLateMinuteField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        perLateMinuteField.delegate = self
         latenessFineField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
         absenceFineField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
         
@@ -54,17 +53,22 @@ class EditingStudyGeneralRuleAttendanceFineTableViewCell: UITableViewCell {
     // MARK: - Actions
     
     @objc func roundedNumberFieldDidChanged(_ sender: RoundedNumberField) {
-        print(sender)
+    
         switch sender {
         case perLateMinuteField:
             perLateMinuteFieldAction(perLateMinuteField.text?.toInt())
         case latenessFineField:
-            latenessFineFieldAction(latenessFineField.text?.toInt())
+            latenessFineFieldAction(latenessFineField.text?.toInt() == 0 ? nil : latenessFineField.text?.toInt())
         case absenceFineField:
-            absenceFineFieldAction(absenceFineField.text?.toInt())
+            absenceFineFieldAction(absenceFineField.text?.toInt() == 0 ? nil : absenceFineField.text?.toInt())
         default:
             return
         }
+    }
+    
+    func fineDimmingViewAddTapGesture(target: Any?, action: Selector) {
+        print("초기화","🔥")
+        fineDimmingView.addGestureRecognizer(UITapGestureRecognizer(target: target, action: action))
     }
     
     // MARK: - Configure
@@ -83,6 +87,7 @@ class EditingStudyGeneralRuleAttendanceFineTableViewCell: UITableViewCell {
         contentView.addSubview(absenceFineCountLabel)
         contentView.addSubview(absenceFineField)
         contentView.addSubview(absenceFineFieldBehindLabel)
+        contentView.addSubview(fineDimmingView)
     }
     
     // MARK: - Setting Constraints
@@ -146,6 +151,17 @@ class EditingStudyGeneralRuleAttendanceFineTableViewCell: UITableViewCell {
             make.leading.equalTo(absenceFineField.snp.trailing).offset(2)
             make.width.equalTo(20)
             make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+        }
+        fineDimmingView.snp.makeConstraints { make in
+            make.edges.equalTo(contentView.safeAreaLayoutGuide)
+        }
+    }
+}
+
+extension EditingStudyGeneralRuleAttendanceFineTableViewCell: UITextFieldDelegate {
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        if textField == perLateMinuteField {
+            perLateMinuteFieldAction(textField.text?.toInt())
         }
     }
 }

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceFineTableViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceFineTableViewCell.swift
@@ -1,0 +1,151 @@
+//
+//  EditingStudyGeneralRuleAttendanceFineTableViewCell.swift
+//  STUDYA
+//
+//  Created by 서동운 on 12/27/22.
+//
+
+import UIKit
+
+class EditingStudyGeneralRuleAttendanceFineTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier = "EditingStudyGeneralRuleAttendanceFineTableViewCell"
+    
+    let fineTitleLabel = CustomLabel(title: "벌금 규칙", tintColor: .ppsBlack, size: 16, isBold: true)
+    let fineDescriptionLabel = CustomLabel(title: "* 출석체크 시, 입력하신 규칙에 따라 벌금이 자동으로 계산돼요.", tintColor: .ppsGray1, size: 12)
+    
+    let perLateMinuteFieldLabel = CustomLabel(title: "지각", tintColor: .ppsBlack, size: 16)
+    let perLateMinuteFieldBehindLabel = CustomLabel(title: "분당", tintColor: .ppsBlack, size: 16)
+    let latenessFineFieldBehindLabel = CustomLabel(title: "원", tintColor: .ppsBlack, size: 16)
+    let absenceFineCountLabel = CustomLabel(title: "결석 1회당", tintColor: .ppsBlack, size: 16)
+    let absenceFineFieldBehindLabel = CustomLabel(title: "원", tintColor: .ppsBlack, size: 16)
+    
+    /// 벌금규칙
+    let perLateMinuteField = RoundedNumberField(numPlaceholder: nil, centerAlign: true)
+    let latenessFineField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: true)
+    let absenceFineField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: true)
+    
+    /// 디밍처리
+    lazy var fineDimmingView = UIView()
+    
+    var perLateMinuteFieldAction: (Int?) -> Void = { perLateMinute in }
+    var latenessFineFieldAction: (Int?) -> Void = { latenessFine in }
+    var absenceFineFieldAction: (Int?) -> Void = { absenceFine in }
+
+    // MARK: - Initialization
+   
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        perLateMinuteField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        latenessFineField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        absenceFineField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        
+        configureViews()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    
+    @objc func roundedNumberFieldDidChanged(_ sender: RoundedNumberField) {
+        print(sender)
+        switch sender {
+        case perLateMinuteField:
+            perLateMinuteFieldAction(perLateMinuteField.text?.toInt())
+        case latenessFineField:
+            latenessFineFieldAction(latenessFineField.text?.toInt())
+        case absenceFineField:
+            absenceFineFieldAction(absenceFineField.text?.toInt())
+        default:
+            return
+        }
+    }
+    
+    // MARK: - Configure
+    
+    private func configureViews() {
+        
+        selectionStyle = .none
+        
+        contentView.addSubview(fineTitleLabel)
+        contentView.addSubview(fineDescriptionLabel)
+        contentView.addSubview(perLateMinuteFieldLabel)
+        contentView.addSubview(perLateMinuteField)
+        contentView.addSubview(perLateMinuteFieldBehindLabel)
+        contentView.addSubview(latenessFineField)
+        contentView.addSubview(latenessFineFieldBehindLabel)
+        contentView.addSubview(absenceFineCountLabel)
+        contentView.addSubview(absenceFineField)
+        contentView.addSubview(absenceFineFieldBehindLabel)
+    }
+    
+    // MARK: - Setting Constraints
+    
+    private func setConstraints() {
+        
+        fineTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(contentView.safeAreaLayoutGuide).inset(18)
+            make.leading.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        
+        fineDescriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(fineTitleLabel.snp.bottom).offset(5)
+            make.leading.equalTo(fineTitleLabel)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        
+        perLateMinuteFieldLabel.snp.makeConstraints { make in
+            make.top.equalTo(fineDescriptionLabel.snp.bottom).offset(12)
+            make.leading.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+        }
+        
+        perLateMinuteField.snp.makeConstraints { make in
+            make.top.equalTo(perLateMinuteFieldLabel.snp.bottom).offset(3)
+            make.leading.equalTo(fineDescriptionLabel)
+            make.width.equalTo(75)
+        }
+        
+        perLateMinuteFieldBehindLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(perLateMinuteField)
+            make.width.equalTo(30)
+            make.leading.equalTo(perLateMinuteField.snp.trailing).offset(2)
+        }
+        
+        latenessFineField.snp.makeConstraints { make in
+            make.centerY.equalTo(perLateMinuteFieldBehindLabel)
+            make.leading.equalTo(perLateMinuteFieldBehindLabel.snp.trailing).offset(2)
+            make.width.greaterThanOrEqualTo(150)
+        }
+        
+        latenessFineFieldBehindLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(latenessFineField)
+            make.leading.equalTo(latenessFineField.snp.trailing).offset(2)
+            make.width.equalTo(20)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+        }
+        
+        absenceFineCountLabel.snp.makeConstraints { make in
+            make.top.equalTo(perLateMinuteField.snp.bottom).offset(20)
+            make.leading.equalTo(perLateMinuteField)
+        }
+        
+        absenceFineField.snp.makeConstraints { make in
+            make.top.equalTo(absenceFineCountLabel.snp.bottom).offset(3)
+            make.leading.equalTo(perLateMinuteField)
+            make.bottom.equalTo(contentView.safeAreaLayoutGuide).inset(20)
+        }
+        
+        absenceFineFieldBehindLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(absenceFineField)
+            make.leading.equalTo(absenceFineField.snp.trailing).offset(2)
+            make.width.equalTo(20)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+        }
+    }
+}

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift
@@ -32,8 +32,8 @@ class EditingStudyGeneralRuleAttendanceTimeTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        latenessRuleTimeField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
-        absenceRuleTimeField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        latenessRuleTimeField.delegate = self
+        absenceRuleTimeField.delegate = self
         
         configureViews()
         setConstraints()
@@ -46,7 +46,7 @@ class EditingStudyGeneralRuleAttendanceTimeTableViewCell: UITableViewCell {
     // MARK: - Actions
     
     @objc func roundedNumberFieldDidChanged(_ sender: RoundedNumberField) {
-        print(sender)
+       print(sender, "🫣")
         switch sender {
         case latenessRuleTimeField:
             latenessRuleTimeFieldAction(sender.text?.toInt())
@@ -128,6 +128,32 @@ class EditingStudyGeneralRuleAttendanceTimeTableViewCell: UITableViewCell {
             make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
             make.centerY.equalTo(absenceRuleTimeFieldFrontLabel)
             make.width.equalTo(78)
+        }
+    }
+}
+
+extension EditingStudyGeneralRuleAttendanceTimeTableViewCell: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        
+        switch textField {
+        case latenessRuleTimeField:
+            latenessRuleTimeField.pickerSelectRowMatchedTextIn(latenessRuleTimeField)
+        case absenceRuleTimeField:
+            absenceRuleTimeField.pickerSelectRowMatchedTextIn(absenceRuleTimeField)
+        default:
+            return
+        }
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        
+        switch textField {
+        case latenessRuleTimeField:
+            latenessRuleTimeFieldAction(textField.text?.toInt())
+        case absenceRuleTimeField:
+            absenceRuleTimeFieldAction(textField.text?.toInt())
+        default:
+            return
         }
     }
 }

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift
@@ -1,0 +1,133 @@
+//
+//  EditingStudyGeneralRuleAttendanceTimeTableViewCell.swift
+//  STUDYA
+//
+//  Created by 서동운 on 12/27/22.
+//
+
+import UIKit
+
+class EditingStudyGeneralRuleAttendanceTimeTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier = "EditingStudyGeneralRuleAttendanceTimeTableViewCell"
+    
+    let attendanceTitleLabel = CustomLabel(title: "출결 규칙", tintColor: .ppsBlack, size: 16, isBold: true)
+    let attendanceDescriptionLabel = CustomLabel(title: "* 결석 조건을 입력하지 않으면 스터디가 끝나는 시간으로 설정돼요.", tintColor: .ppsGray1, size: 12)
+    let latenessRuleTimeFieldFrontLabel = CustomLabel(title: "스터디 시작 후", tintColor: .ppsBlack, size: 16)
+    let latenessRuleTimeBehindLabel = CustomLabel(title: "분 부터 지각", boldPart: "지각")
+    let absenceRuleTimeFieldFrontLabel = CustomLabel(title: "스터디 시작 후", tintColor: .ppsBlack, size: 16)
+    let absenceRuleTimeFieldBehindLabel = CustomLabel(title: "분 부터 결석", boldPart: "결석")
+
+    
+    let latenessRuleTimeField = RoundedNumberField(numPlaceholder: nil, centerAlign: true)
+    let absenceRuleTimeField = RoundedNumberField(numPlaceholder: nil, centerAlign: true)
+    
+    var latenessRuleTimeFieldAction: (Int?) -> Void = { latenessRuleTime in }
+    var absenceRuleTimeFieldAction: (Int?) -> Void = { absenceRuleTime in }
+
+    
+    // MARK: - Initialization
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        latenessRuleTimeField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        absenceRuleTimeField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
+        
+        configureViews()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    
+    @objc func roundedNumberFieldDidChanged(_ sender: RoundedNumberField) {
+        print(sender)
+        switch sender {
+        case latenessRuleTimeField:
+            latenessRuleTimeFieldAction(sender.text?.toInt())
+        case absenceRuleTimeField:
+            absenceRuleTimeFieldAction(sender.text?.toInt())
+        default:
+            return
+        }
+    }
+    
+    // MARK: - Configure
+    
+    private func configureViews() {
+        
+        selectionStyle = .none
+        
+        contentView.addSubview(attendanceTitleLabel)
+        contentView.addSubview(attendanceDescriptionLabel)
+        
+        attendanceDescriptionLabel.numberOfLines = 0
+        
+        contentView.addSubview(latenessRuleTimeFieldFrontLabel)
+        contentView.addSubview(latenessRuleTimeField)
+        contentView.addSubview(latenessRuleTimeBehindLabel)
+        contentView.addSubview(absenceRuleTimeFieldFrontLabel)
+        contentView.addSubview(absenceRuleTimeField)
+        contentView.addSubview(absenceRuleTimeFieldBehindLabel)
+    }
+    
+    // MARK: - Setting Constraints
+    
+    private func setConstraints() {
+        
+        attendanceTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(contentView.safeAreaLayoutGuide).inset(18)
+            make.leading.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        
+        attendanceDescriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(attendanceTitleLabel.snp.bottom).offset(5)
+            make.leading.equalTo(attendanceTitleLabel)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        
+        latenessRuleTimeFieldFrontLabel.snp.makeConstraints { make in
+            make.top.equalTo(attendanceDescriptionLabel.snp.bottom).offset(26)
+            make.leading.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+            make.width.equalTo(92)
+        }
+        
+        latenessRuleTimeField.snp.makeConstraints { make in
+            make.width.greaterThanOrEqualTo(75)
+            make.leading.equalTo(latenessRuleTimeFieldFrontLabel.snp.trailing).offset(10)
+            make.centerY.equalTo(latenessRuleTimeFieldFrontLabel)
+        }
+        
+        latenessRuleTimeBehindLabel.snp.makeConstraints { make in
+            make.leading.equalTo(latenessRuleTimeField.snp.trailing).offset(10)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+            make.centerY.equalTo(latenessRuleTimeFieldFrontLabel)
+            make.width.equalTo(78)
+        }
+        
+        absenceRuleTimeFieldFrontLabel.snp.makeConstraints { make in
+            make.top.equalTo(latenessRuleTimeFieldFrontLabel.snp.bottom).offset(40)
+            make.leading.equalTo(latenessRuleTimeFieldFrontLabel)
+            make.bottom.equalTo(contentView.safeAreaLayoutGuide).inset(32)
+            make.width.equalTo(92)
+        }
+        
+        absenceRuleTimeField.snp.makeConstraints { make in
+            make.width.greaterThanOrEqualTo(75)
+            make.leading.equalTo(absenceRuleTimeFieldFrontLabel.snp.trailing).offset(10)
+            make.centerY.equalTo(absenceRuleTimeFieldFrontLabel)
+        }
+        
+        absenceRuleTimeFieldBehindLabel.snp.makeConstraints { make in
+            make.leading.equalTo(absenceRuleTimeField.snp.trailing).offset(10)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+            make.centerY.equalTo(absenceRuleTimeFieldFrontLabel)
+            make.width.equalTo(78)
+        }
+    }
+}

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleDepositTableViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleDepositTableViewCell.swift
@@ -17,17 +17,18 @@ class EditingStudyGeneralRuleDepositTableViewCell: UITableViewCell {
     let depositBehindLabel = CustomLabel(title: "원", tintColor: .ppsBlack, size: 16)
   
     /// 보증금
-    let depositTextField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: false)
-    
-    /// 디밍처리
-    let depositDimmingView = UIView()
+    let depositTextField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: true)
     
     var depositTextFieldAction: (Int?) -> Void = { deposit in }
+    
+    lazy var depositDimmingView = UIView()
 
     // MARK: - Initialization
    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        depositTextField.addTarget(self, action: #selector(roundedNumberFieldDidChanged), for: .editingChanged)
         
         configureViews()
         setConstraints()
@@ -37,6 +38,16 @@ class EditingStudyGeneralRuleDepositTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     // MARK: - Actions
+    
+    @objc func roundedNumberFieldDidChanged(_ sender: RoundedNumberField) {
+
+        switch sender {
+        case depositTextField:
+            depositTextFieldAction(depositTextField.text?.toInt() == 0 ? nil : depositTextField.text?.toInt())
+        default:
+            return
+        }
+    }
     
     
     // MARK: - Configure

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleDepositTableViewCell.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleDepositTableViewCell.swift
@@ -1,0 +1,72 @@
+//
+//  EditingStudyGeneralRuleDepositTableViewCell.swift
+//  STUDYA
+//
+//  Created by 서동운 on 12/27/22.
+//
+
+import UIKit
+
+class EditingStudyGeneralRuleDepositTableViewCell: UITableViewCell {
+    
+    // MARK: - Properties
+    
+    static let identifier = "EditingStudyGeneralRuleDepositTableViewCell"
+    
+    let depositTitleLabel = CustomLabel(title: "보증금", tintColor: .ppsBlack, size: 16, isBold: true)
+    let depositBehindLabel = CustomLabel(title: "원", tintColor: .ppsBlack, size: 16)
+  
+    /// 보증금
+    let depositTextField = RoundedNumberField(numPlaceholder: 0, centerAlign: false, isPicker: false, isNecessary: false)
+    
+    /// 디밍처리
+    let depositDimmingView = UIView()
+    
+    var depositTextFieldAction: (Int?) -> Void = { deposit in }
+
+    // MARK: - Initialization
+   
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        configureViews()
+        setConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    // MARK: - Actions
+    
+    
+    // MARK: - Configure
+    
+    private func configureViews() {
+        
+        selectionStyle = .none
+        
+        contentView.addSubview(depositTitleLabel)
+        contentView.addSubview(depositTextField)
+        contentView.addSubview(depositBehindLabel)
+    }
+
+    // MARK: - Setting Constraints
+    
+    private func setConstraints() {
+        depositTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(contentView.safeAreaLayoutGuide).inset(18)
+            make.leading.equalTo(contentView.safeAreaLayoutGuide).inset(30)
+        }
+        depositTextField.snp.makeConstraints { make in
+            make.top.equalTo(depositTitleLabel.snp.bottom).offset(7)
+            make.leading.equalTo(depositTitleLabel)
+            make.bottom.equalTo(contentView.safeAreaLayoutGuide).inset(120)
+        }
+        depositBehindLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(depositTextField)
+            make.width.equalTo(20)
+            make.leading.equalTo(depositTextField.snp.trailing).offset(2)
+            make.trailing.equalTo(contentView.safeAreaLayoutGuide).inset(40)
+        }
+    }
+}

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleViewController.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleViewController.swift
@@ -11,7 +11,17 @@ final class EditingStudyGeneralRuleViewController: UIViewController {
 
     // MARK: - Model
     
-    var study: Study?
+    var study: Study? {
+        didSet {
+            if oldValue == nil {
+                doneButtonItem.isEnabled = false
+            } else if study == oldValue {
+                doneButtonItem.isEnabled = false
+            } else {
+                doneButtonItem.isEnabled = true
+            }
+        }
+    }
     
     // MARK: - UI Properties
     
@@ -26,11 +36,15 @@ final class EditingStudyGeneralRuleViewController: UIViewController {
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
         
+        collectionView.isScrollEnabled = false
+        
         return collectionView
     }()
     private let underLine = UIView()
     private lazy var leftTabButton: UIButton = tabButton(title: "출결&벌금")
     private lazy var rightTabButton: UIButton = tabButton(title: "강퇴")
+    
+    private lazy var doneButtonItem = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(ruleEditDone))
     
     // MARK: - Life Cycle
     
@@ -63,9 +77,6 @@ final class EditingStudyGeneralRuleViewController: UIViewController {
                     make.centerX.equalTo(rightTabButton)
                 }
                 contentView.scrollToItem(at: IndexPath(row: 1, section: 0), at: .centeredHorizontally, animated: true)
-                
-                /// 근데 맨처음에는 실행되지않음.
-                /// cellForRowAt에서 코드 추가해주어서 해결.
             default:
                 return
         }
@@ -106,7 +117,7 @@ final class EditingStudyGeneralRuleViewController: UIViewController {
     func setNavigation() {
         
         self.navigationItem.title = "규칙 관리"
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(ruleEditDone))
+        self.navigationItem.rightBarButtonItem = doneButtonItem
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .done, target: self, action: #selector(cancel))
         self.navigationItem.rightBarButtonItem?.tintColor = .appColor(.cancel)
         self.navigationItem.leftBarButtonItem?.tintColor = .appColor(.cancel)

--- a/STUDYA/STUDYA/EditingStudyGeneralRuleViewController.swift
+++ b/STUDYA/STUDYA/EditingStudyGeneralRuleViewController.swift
@@ -1,0 +1,277 @@
+//
+//  EditingStudyGeneralRuleViewController.swift
+//  STUDYA
+//
+//  Created by 서동운 on 2022/12/27.
+//
+
+import UIKit
+
+final class EditingStudyGeneralRuleViewController: UIViewController {
+
+    // MARK: - Model
+    
+    var study: Study?
+    
+    // MARK: - UI Properties
+    
+    private let separateBar = UIView()
+    private let topScrollView = UIScrollView()
+    private let contentView: UICollectionView = {
+        
+        let flowLayout = UICollectionViewFlowLayout()
+        
+        flowLayout.scrollDirection = .horizontal
+        flowLayout.minimumLineSpacing = 0
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
+        
+        return collectionView
+    }()
+    private let underLine = UIView()
+    private lazy var leftTabButton: UIButton = tabButton(title: "출결&벌금")
+    private lazy var rightTabButton: UIButton = tabButton(title: "강퇴")
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setNavigation()
+        configureViews()
+        setConstraints()
+    }
+
+    // MARK: - Actions
+    
+    @objc func tabButtonTapped(_ sender: UIButton) {
+        
+        switch sender {
+            case leftTabButton:
+                underLine.snp.remakeConstraints { make in
+                    make.height.equalTo(6)
+                    make.width.equalTo(86)
+                    make.bottom.equalTo(topScrollView).inset(-3)
+                    make.centerX.equalTo(leftTabButton)
+                }
+                contentView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: true)
+            case rightTabButton:
+                underLine.snp.remakeConstraints { make in
+                    make.height.equalTo(6)
+                    make.width.equalTo(86)
+                    make.bottom.equalTo(topScrollView).inset(-3)
+                    make.centerX.equalTo(rightTabButton)
+                }
+                contentView.scrollToItem(at: IndexPath(row: 1, section: 0), at: .centeredHorizontally, animated: true)
+                
+                /// 근데 맨처음에는 실행되지않음.
+                /// cellForRowAt에서 코드 추가해주어서 해결.
+            default:
+                return
+        }
+        
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        } completion: { _ in
+            sender.isSelected = true
+            [self.leftTabButton, self.rightTabButton].filter({ button in
+                button != sender
+            }).forEach { button in
+                button.isSelected = false
+            }
+        }
+    }
+    
+    @objc func ruleEditDone() {
+        
+        guard let study = study else { return }
+        guard let studyID = study.id else { return }
+        Network.shared.updateStudy(study, id: studyID) { result in
+            switch result {
+            case .success(let success):
+                print(success)
+                self.dismiss(animated: true)
+            case .failure(let failure):
+                print(failure)
+            }
+        }
+    }
+    
+    @objc func cancel() {
+        self.dismiss(animated: true)
+    }
+    
+    // MARK: - Configure
+    
+    func setNavigation() {
+        
+        self.navigationItem.title = "규칙 관리"
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "확인", style: .done, target: self, action: #selector(ruleEditDone))
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .done, target: self, action: #selector(cancel))
+        self.navigationItem.rightBarButtonItem?.tintColor = .appColor(.cancel)
+        self.navigationItem.leftBarButtonItem?.tintColor = .appColor(.cancel)
+    }
+    
+    private func configureViews() {
+        
+        view.backgroundColor = .systemBackground
+        
+        addTopScrollView()
+        addContentView()
+        addTabButtonAtTopScrollView()
+        addSeparateBar()
+        addUnderLine()
+    }
+    
+    private func addTopScrollView() {
+        
+        view.addSubview(topScrollView)
+        
+        topScrollView.backgroundColor = .white
+        
+        topScrollView.showsHorizontalScrollIndicator = false
+        topScrollView.showsVerticalScrollIndicator = false
+    }
+    
+    private func addContentView() {
+        
+        view.addSubview(contentView)
+        
+        contentView.isPagingEnabled = true
+        
+        contentView.delegate = self
+        contentView.dataSource = self
+        
+        contentView.showsHorizontalScrollIndicator = false
+        contentView.showsVerticalScrollIndicator = false
+        
+        contentView.bounces = false
+        
+        contentView.register(EditingStudyGeneralRuleAttendanceCollectionViewCell.self, forCellWithReuseIdentifier: EditingStudyGeneralRuleAttendanceCollectionViewCell.identifier)
+        contentView.register(EditingExcommunicationRuleCollectionViewCell.self, forCellWithReuseIdentifier: EditingExcommunicationRuleCollectionViewCell.identifier)
+    }
+    
+    private func addTabButtonAtTopScrollView(){
+        
+        topScrollView.addSubview(leftTabButton)
+        topScrollView.addSubview(rightTabButton)
+        
+        leftTabButton.isSelected = true
+    }
+    
+    private func tabButton(title: String) -> UIButton {
+        
+        let button = UIButton()
+        
+        button.setTitle(title, for: .normal)
+        button.setTitle(title, for: .selected)
+        
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        
+        button.setTitleColor(.appColor(.ppsGray2), for: .normal)
+        button.setTitleColor(.appColor(.ppsBlack), for: .selected)
+        
+        button.addTarget(self, action: #selector(tabButtonTapped), for: .touchUpInside)
+        
+        return button
+    }
+    
+    private func addSeparateBar() {
+        
+        view.addSubview(separateBar)
+        
+        separateBar.backgroundColor = .appColor(.keyColor3)
+        separateBar.clipsToBounds = true
+        separateBar.layer.cornerRadius = 1 / 2
+    }
+    
+    private func addUnderLine() {
+        
+        view.addSubview(underLine)
+        
+        underLine.clipsToBounds = true
+        underLine.layer.cornerRadius = 6 / 2
+        underLine.backgroundColor = .appColor(.keyColor3)
+    }
+    
+    // MARK: - Setting Constraints
+    
+    private func setConstraints() {
+        
+        topScrollView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.height.equalTo(41) // 또는 40
+        }
+        contentView.snp.makeConstraints { make in
+            make.top.equalTo(topScrollView.snp.bottom)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
+            make.bottom.equalTo(view)
+        }
+        
+        leftTabButton.snp.makeConstraints { make in
+            make.top.leading.bottom.equalTo(topScrollView)
+            make.width.equalTo(view.frame.width / 2)
+            make.height.equalTo(41)
+        }
+        
+        rightTabButton.snp.makeConstraints { make in
+            make.leading.equalTo(leftTabButton.snp.trailing)
+            make.top.trailing.bottom.equalTo(topScrollView)
+            make.width.equalTo(view.frame.width / 2)
+            make.height.equalTo(41)
+        }
+        
+        separateBar.snp.makeConstraints { make in
+            make.bottom.equalTo(topScrollView)
+            make.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(1)
+            make.height.equalTo(1)
+        }
+        
+        underLine.snp.makeConstraints { make in
+            make.height.equalTo(6)
+            make.width.equalTo(86)
+            make.bottom.equalTo(topScrollView).inset(-3)
+            make.centerX.equalTo(leftTabButton)
+        }
+    }
+}
+
+extension EditingStudyGeneralRuleViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        2
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch indexPath.item {
+        case 0:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditingStudyGeneralRuleAttendanceCollectionViewCell.identifier, for: indexPath) as? EditingStudyGeneralRuleAttendanceCollectionViewCell else { return UICollectionViewCell() }
+            
+            cell.delegate = self
+            
+            return cell
+        case 1:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditingExcommunicationRuleCollectionViewCell.identifier, for: indexPath) as? EditingExcommunicationRuleCollectionViewCell else { return UICollectionViewCell() }
+            
+            cell.latenessCountField.text = study?.generalRule?.excommunication.lateness?.toString()
+            cell.absenceCountField.text = study?.generalRule?.excommunication.absence?.toString()
+            
+            cell.latenessCountFieldAction = { [self] latenessCount in
+                study?.generalRule?.excommunication.lateness = latenessCount
+            }
+            cell.absenceCountFieldAction = { [self] absenceCount in
+                study?.generalRule?.excommunication.absence = absenceCount
+            }
+            
+            return cell
+        default:
+            return UICollectionViewCell()
+        }
+    }
+}
+
+extension EditingStudyGeneralRuleViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return contentView.frame.size
+    }
+}

--- a/STUDYA/STUDYA/Extension.swift
+++ b/STUDYA/STUDYA/Extension.swift
@@ -98,10 +98,11 @@ extension UIView {
 }
 
 extension UIView {
-    convenience init(backgroundColor: UIColor) {
+    convenience init(backgroundColor: UIColor, alpha: CGFloat = 1) {
         self.init(frame: .zero)
         
         self.backgroundColor = backgroundColor
+        self.alpha = alpha
         
     }
 }

--- a/STUDYA/STUDYA/Extension.swift
+++ b/STUDYA/STUDYA/Extension.swift
@@ -106,6 +106,12 @@ extension UIView {
     }
 }
 
+extension Int {
+    func toString() -> String {
+        return String(self)
+    }
+}
+
 extension String {
     func checkOnlyNumbers() -> Bool {
         do {
@@ -118,6 +124,10 @@ extension String {
             return false
         }
         return false
+    }
+    
+    func toInt() -> Int? {
+        return Int(self)
     }
 }
 

--- a/STUDYA/STUDYA/GeneralRuleAttendanceTableView.swift
+++ b/STUDYA/STUDYA/GeneralRuleAttendanceTableView.swift
@@ -8,31 +8,23 @@
 import UIKit
 
 class GeneralRuleAttendanceTableView: UITableView {
+    
     // MARK: - Properties
-    
-    lazy var toastMessage = ToastMessage(message: "먼저 지각 규칙을 입력해주세요.", messageColor: .whiteLabel, messageSize: 12, image: "alert")
-    
-    private var keyboardFrameHeight: CGFloat = 0
     
     // MARK: - Initialization
     
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
-        
-//        addTapGestureRecognizers()
-//
-//        setDelegate()
-//        setNotification()
-        
+    
         registerCells()
         configureViews()
-        setConstaints()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     // MARK: - Actions
+    
     // MARK: - Configure
     
     func configureViews() {
@@ -41,24 +33,11 @@ class GeneralRuleAttendanceTableView: UITableView {
         
         separatorStyle = .none
         alwaysBounceVertical = false
-//        addSubview(toastMessage)
-    
     }
     
     private func registerCells() {
         register(EditingStudyGeneralRuleAttendanceTimeTableViewCell.self, forCellReuseIdentifier: EditingStudyGeneralRuleAttendanceTimeTableViewCell.identifier)
         register(EditingStudyGeneralRuleAttendanceFineTableViewCell.self, forCellReuseIdentifier: EditingStudyGeneralRuleAttendanceFineTableViewCell.identifier)
         register(EditingStudyGeneralRuleDepositTableViewCell.self, forCellReuseIdentifier: EditingStudyGeneralRuleDepositTableViewCell.identifier)
-    }
-    // MARK: - Setting Constraints
-    
-    func setConstaints() {
-//        toastMessage.snp.makeConstraints { make in
-//            make.centerX.equalTo(view)
-//            make.width.equalTo(view.frame.width - 14)
-//            make.height.equalTo(42)
-//            guard let bottomConstraintItem = bottomConstraintItem else { return }
-//            make.bottom.equalTo(bottomConstraintItem).offset(-keyboardFrameHeight + 100)
-//        }
     }
 }

--- a/STUDYA/STUDYA/GeneralRuleAttendanceTableView.swift
+++ b/STUDYA/STUDYA/GeneralRuleAttendanceTableView.swift
@@ -1,0 +1,64 @@
+//
+//  GeneralRuleAttendanceTableView.swift
+//  STUDYA
+//
+//  Created by 서동운 on 12/27/22.
+//
+
+import UIKit
+
+class GeneralRuleAttendanceTableView: UITableView {
+    // MARK: - Properties
+    
+    lazy var toastMessage = ToastMessage(message: "먼저 지각 규칙을 입력해주세요.", messageColor: .whiteLabel, messageSize: 12, image: "alert")
+    
+    private var keyboardFrameHeight: CGFloat = 0
+    
+    // MARK: - Initialization
+    
+    override init(frame: CGRect, style: UITableView.Style) {
+        super.init(frame: frame, style: style)
+        
+//        addTapGestureRecognizers()
+//
+//        setDelegate()
+//        setNotification()
+        
+        registerCells()
+        configureViews()
+        setConstaints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    // MARK: - Actions
+    // MARK: - Configure
+    
+    func configureViews() {
+        
+        backgroundColor = .appColor(.background)
+        
+        separatorStyle = .none
+        alwaysBounceVertical = false
+//        addSubview(toastMessage)
+    
+    }
+    
+    private func registerCells() {
+        register(EditingStudyGeneralRuleAttendanceTimeTableViewCell.self, forCellReuseIdentifier: EditingStudyGeneralRuleAttendanceTimeTableViewCell.identifier)
+        register(EditingStudyGeneralRuleAttendanceFineTableViewCell.self, forCellReuseIdentifier: EditingStudyGeneralRuleAttendanceFineTableViewCell.identifier)
+        register(EditingStudyGeneralRuleDepositTableViewCell.self, forCellReuseIdentifier: EditingStudyGeneralRuleDepositTableViewCell.identifier)
+    }
+    // MARK: - Setting Constraints
+    
+    func setConstaints() {
+//        toastMessage.snp.makeConstraints { make in
+//            make.centerX.equalTo(view)
+//            make.width.equalTo(view.frame.width - 14)
+//            make.height.equalTo(42)
+//            guard let bottomConstraintItem = bottomConstraintItem else { return }
+//            make.bottom.equalTo(bottomConstraintItem).offset(-keyboardFrameHeight + 100)
+//        }
+    }
+}

--- a/STUDYA/STUDYA/MainSixthETCTableViewCell.swift
+++ b/STUDYA/STUDYA/MainSixthETCTableViewCell.swift
@@ -87,8 +87,7 @@ class MainSixthETCTableViewCell: UITableViewCell {
     @objc private func informationButtonTapped() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let nextVC  = storyboard.instantiateViewController(withIdentifier: "StudyInfoViewController") as! StudyInfoViewController
-        
-        nextVC.study = self.currentStudy
+    
         navigatableSwitchSyncableDelegate.syncSwitchWith(nextVC: nextVC)
         navigatableSwitchSyncableDelegate.push(vc: nextVC)
     }

--- a/STUDYA/STUDYA/MainViewController.swift
+++ b/STUDYA/STUDYA/MainViewController.swift
@@ -92,7 +92,7 @@ final class MainViewController: SwitchableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 //        📣네트워킹으로 myStudyList 넣어주기
-        getUserInformationAndStudies()
+//        getUserInformationAndStudies()
 //        myStudyList = [
 //            Study(id: 1, studyName: "웃기지마", studyOn: true, studyOff: false, category: .dev_prod_design, studyIntroduction: "우리의 스터디", freeRule: "강남역에서 종종 모여서 앱을 개발하는 스터디라고 할 수 있는 부분이 없지 않아 있다고 생각하는 부분이라고 봅니다.", isBlocked: nil, isPaused: nil, generalRule: GeneralStudyRule(lateness: Lateness(time: 10, count: 1, fine: 5000), absence: Absence(time: 30, fine: 10000), deposit: 10000, excommunication: Excommunication(lateness: 10, absence: 5))),
 //            Study(id: 2, studyName: "무한도전", studyOn: true, studyOff: false, category: .dev_prod_design, studyIntroduction: "우리의 스터디", freeRule: "대리운전 불러어어어어 단거어어어어어어어어", isBlocked: nil, isPaused: nil, generalRule: GeneralStudyRule(lateness: Lateness(time: 10, count: 1, fine: 5000), absence: Absence(time: 30, fine: 10000), deposit: 10000, excommunication: Excommunication(lateness: 10, absence: 5))),
@@ -110,7 +110,7 @@ final class MainViewController: SwitchableViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        getUserInformationAndStudies()
         tabBarController?.tabBar.isHidden = false
         
 //        let appearance = UINavigationBarAppearance()

--- a/STUDYA/STUDYA/Model.swift
+++ b/STUDYA/STUDYA/Model.swift
@@ -70,7 +70,7 @@ struct SNSInfo {
     let provider: String
 }
 
-struct Study: Codable {
+struct Study: Codable, Equatable {
     let id: Int?
     var studyOn, studyOff: Bool
     var studyName, category, studyIntroduction, freeRule: String?
@@ -101,6 +101,10 @@ struct Study: Codable {
         self.isBlocked = isBlocked
         self.isPaused = isPaused
         self.generalRule = generalRule
+    }
+    
+    static func == (lhs: Study, rhs: Study) -> Bool {
+        return lhs.generalRule?.lateness == rhs.generalRule?.lateness && lhs.generalRule?.absence == rhs.generalRule?.absence && lhs.generalRule?.deposit == rhs.generalRule?.deposit && lhs.generalRule?.excommunication == rhs.generalRule?.excommunication
     }
 }
 
@@ -173,7 +177,8 @@ enum OnOff: String {
     }
 }
 
-struct GeneralStudyRule: Codable {
+struct GeneralStudyRule: Codable, Equatable {
+    
     var lateness: Lateness
     var absence: Absence
     var deposit: Int?
@@ -186,15 +191,15 @@ struct GeneralStudyRule: Codable {
     }
 }
 
-struct Absence: Codable {
+struct Absence: Codable, Equatable {
     var time, fine: Int?
 }
 
-struct Lateness: Codable {
+struct Lateness: Codable, Equatable {
     var time, count, fine: Int?
 }
 
-struct Excommunication: Codable {
+struct Excommunication: Codable, Equatable {
     var lateness, absence: Int?
 
     enum CodingKeys: String, CodingKey {
@@ -229,27 +234,22 @@ struct Announcement: Codable {
     let id: Int?
     let title: String?
     let content: String?
-    let createdAt: String?
+    let createdDate: Date?
     var isPinned: Bool?
-    
-    var createdDate: Date? {
-        guard let createdAt = createdAt else { return nil }
-        return Formatter.formatToDate(string: createdAt)
-    }
     
     enum CodingKeys: String, CodingKey {
         case id = "notificationId"
         case title = "notificationSubject"
         case content = "notificationContents"
-        case createdAt
+        case createdDate = "createdAt"
         case isPinned = "pin"
     }
     
-    init(id: Int? = nil, title: String?, content: String?, createdAt: String?, isPinned: Bool? = nil) {
+    init(id: Int? = nil, title: String?, content: String?, createdDate: Date?, isPinned: Bool? = nil) {
         self.id = id
         self.title = title
         self.content = content
-        self.createdAt = createdAt
+        self.createdDate = createdDate
         self.isPinned = isPinned
     }
 }

--- a/STUDYA/STUDYA/Model.swift
+++ b/STUDYA/STUDYA/Model.swift
@@ -240,7 +240,7 @@ struct Schedule: Codable {
     let id: Int?
     let name: String?
     let date: Date?
-    let status: String? //상태가 머머 있는거지?
+    let status: String?
     
     enum CodingKeys: String, CodingKey {
         case status

--- a/STUDYA/STUDYA/MyPageMainViewController.swift
+++ b/STUDYA/STUDYA/MyPageMainViewController.swift
@@ -112,7 +112,12 @@ final class MyPageMainViewController: UIViewController {
             case .success(let user):
                 completion(user)
             case .failure(let error):
-                print(error)
+                switch error {
+                case .unauthorizedUser:
+                    AppController.shared.deleteUserInformationAndLogout()
+                default:
+                    print(error)
+                }
             }
         }
     }

--- a/STUDYA/STUDYA/Network.swift
+++ b/STUDYA/STUDYA/Network.swift
@@ -516,8 +516,12 @@ struct Network {
             
             switch httpResponse.statusCode {
             case 200:
-                guard let body = response.data, let study = jsonDecode(type: Study.self, data: body) else { return }
+                guard let body = response.data,
+                      let studyAllInfo = jsonDecode(type: StudyAllInfo.self, data: body) else { completion(.failure(.decodingError))
+                    return
+                }
                 
+                let study = studyAllInfo.study
                 completion(.success(study))
             default:
                 seperateCommonErrors(statusCode: httpResponse.statusCode) { result in
@@ -868,6 +872,22 @@ extension UIAlertController {
 }
 
 // MARK: - Networking Model
+
+struct StudyAllInfo: Codable {
+    let announcement: Announcement?
+    let study: Study
+    let manager: Bool?
+    let latenessCnt, holdCnt: Int
+    let studySchedule: StudySchedule?
+    let absentCnt, dayCnt: Int
+    let master: Bool?
+    let totalFine, attendanceCnt: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case announcement = "notification"
+        case study, manager, latenessCnt, holdCnt, studySchedule, absentCnt, dayCnt, master, totalFine, attendanceCnt
+    }
+}
 
 struct ResponseResult<T: Codable>: Codable {
     let result: T?

--- a/STUDYA/STUDYA/StudyExitViewController.swift
+++ b/STUDYA/STUDYA/StudyExitViewController.swift
@@ -10,6 +10,9 @@ import SnapKit
 
 class StudyExitViewController: UIViewController {
     
+    var studyName: String?
+    var studyID: ID?
+    
     let task: StudyExitBottomSheetTask
     weak var presentingVC: UIViewController?
     
@@ -44,7 +47,7 @@ class StudyExitViewController: UIViewController {
                 titleLabel = CustomLabel(title: "이 스터디에서 탈퇴할까요?", tintColor: .ppsBlack, size: 18, isBold: true)
                 subtitleLabel = CustomLabel(title: "스터디에서 탈퇴해도 초대 링크를 통해\n다시 참여할 수 있어요.", tintColor: .ppsGray1, size: 14)
             case .close:
-                titleLabel = CustomLabel(title: "{스터디명}을 종료할까요?", tintColor: .ppsBlack, size: 18, isBold: true)
+                titleLabel = CustomLabel(title: "\(studyName ?? "스터디")을(를) 종료할까요?", tintColor: .ppsBlack, size: 18, isBold: true)
                 subtitleLabel = CustomLabel(title: "스터디를 종료한 이후에는\n스터디방을 다시 복구할 수 없어요.", tintColor: .ppsGray1, size: 14)
             case .resignMaster:
                 titleLabel = CustomLabel(title: "지금은 탈퇴할 수 없어요.", tintColor: .ppsBlack, size: 18, isBold: true)
@@ -118,9 +121,20 @@ class StudyExitViewController: UIViewController {
                         
                         presentingVC?.present(vcToPresent, animated: true)
                     }
-                    
-                case .close, .resignMaster:
-                    self.dismiss(animated: true)
+                
+            case .close:
+                guard let studyID = studyID else { return }
+                Network.shared.deleteStudy(studyID) { result in
+                    switch result {
+                    case .success(_):
+                        print("스터디 탈퇴 성공")
+                        self.dismiss(animated: true)
+                    case .failure(let error):
+                        print(error)
+                    }
+                }
+            case.resignMaster:
+                self.dismiss(animated: true)
             }
         } else {
             self.dismiss(animated: true)

--- a/STUDYA/STUDYA/StudyGeneralRuleAttendanceCollectionViewCell.swift
+++ b/STUDYA/STUDYA/StudyGeneralRuleAttendanceCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  AttendanceRuleCollectionViewCell.swift
+//  CreatingStudyGeneralRuleAttendanceCollectionViewCell.swift
 //  STUDYA
 //
 //  Created by 신동훈 on 2022/09/02.
@@ -7,9 +7,9 @@
 
 import UIKit
 
-class AttendanceRuleCollectionViewCell: UICollectionViewCell {
+class CreatingStudyGeneralRuleAttendanceCollectionViewCell: UICollectionViewCell {
 
-    static let identifier = "AttendanceRuleCollectionViewCell"
+    static let identifier = "CreatingStudyGeneralRuleAttendanceCollectionViewCell"
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/STUDYA/STUDYA/StudyGeneralRuleAttendanceTableViewController.swift
+++ b/STUDYA/STUDYA/StudyGeneralRuleAttendanceTableViewController.swift
@@ -51,8 +51,6 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
         setup(depositTextField)
         
         fineAndDepositFieldsAreEnabled(false)
-        
-        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(sender:))))
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -91,13 +89,14 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
     }
     
     private func setNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(onKeyboardAppear(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(onKeyboardDisappear(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardAppear(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardDisappear(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     private func addTapGestureRecognizers() {
         fineDimmingView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dimmingViewDidTapped)))
         depositDimmingView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dimmingViewDidTapped)))
+        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(sender:))))
     }
     
     private func setup(_ textField: UITextField) {
@@ -111,7 +110,7 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
         textField.textAlignment = .right
         textField.clipsToBounds = true
         textField.layer.cornerRadius = 42 / 2
-//        textField.keyboardType = .numberPad
+        textField.keyboardType = .numberPad
     }
     
     func fineAndDepositFieldsAreEnabled(_ bool: Bool) {
@@ -158,7 +157,7 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
         }
     }
     
-    @objc func onKeyboardAppear(_ notification: NSNotification) {
+    @objc func keyboardAppear(_ notification: NSNotification) {
         
         guard let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         
@@ -166,7 +165,7 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
         keyboardFrameHeight = keyboardSize.height
     }
     
-    @objc func onKeyboardDisappear(_ notification: NSNotification) {
+    @objc func keyboardDisappear(_ notification: NSNotification) {
         keyboardFrameHeight = 0
     }
 }

--- a/STUDYA/STUDYA/StudyGeneralRuleAttendanceTableViewController.swift
+++ b/STUDYA/STUDYA/StudyGeneralRuleAttendanceTableViewController.swift
@@ -41,6 +41,8 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        view.backgroundColor = .appColor(.background)
+        
         addTapGestureRecognizers()
         
         setDelegate()
@@ -114,8 +116,8 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
     }
     
     func fineAndDepositFieldsAreEnabled(_ bool: Bool) {
-        depositDimmingView.isHidden = bool
         fineDimmingView.isHidden = bool
+        depositDimmingView.isHidden = bool
         
         perLateMinuteField.isEnabled = bool
         latenessFineTextField.isEnabled = bool
@@ -174,10 +176,6 @@ class StudyGeneralRuleAttendanceTableViewController: UITableViewController {
 
 extension StudyGeneralRuleAttendanceTableViewController {
     
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 0
-    }
-    
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         if section == 0 || section == 1 {
             return 10
@@ -188,9 +186,7 @@ extension StudyGeneralRuleAttendanceTableViewController {
     
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if section == 0 || section == 1 {
-            let footerView = UIView(frame: CGRect(x: 0, y: 0, width: self.view.frame.width, height: 10))
-            footerView.backgroundColor = .appColor(.background)
-            return footerView
+            return UIView()
         } else {
             return nil
         }

--- a/STUDYA/STUDYA/StudyGeneralRuleExcommunicationCollectionViewCell.swift
+++ b/STUDYA/STUDYA/StudyGeneralRuleExcommunicationCollectionViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  ExcommunicationRuleCollectionViewCell.swift
+//  CreatingExcommunicationRuleCollectionViewCell.swift
 //  STUDYA
 //
 //  Created by 신동훈 on 2022/09/02.
@@ -7,12 +7,12 @@
 
 import UIKit
 
-final class ExcommunicationRuleCollectionViewCell: UICollectionViewCell {
+final class CreatingExcommunicationRuleCollectionViewCell: UICollectionViewCell {
 
     private var validationCheck1 = false
     private var validationCheck2 = false
     
-    static let identifier = "ExcommunicationRuleCollectionViewCell"
+    static let identifier = "CreatingExcommunicationRuleCollectionViewCell"
     private let titleLabel = CustomLabel(title: "강퇴 조건", tintColor: .ppsBlack, size: 16, isBold: true)
     private let descriptionLabel = CustomLabel(title: "* 멤버가 강퇴 조건에 도달하면 관리자에게 알림이 전송돼요.\n* 지각과 결석 조건을 모두 입력하면, 둘 중 하나만 만족해도\n강퇴 조건에 도달해요.", tintColor: .ppsGray1, size: 12)
     internal let lateNumberField = RoundedNumberField(numPlaceholder: nil, centerAlign: false, enable: true, isPicker: true, isNecessary: true)

--- a/STUDYA/STUDYA/SwitchableViewController.swift
+++ b/STUDYA/STUDYA/SwitchableViewController.swift
@@ -89,6 +89,7 @@ class SwitchableViewController: UIViewController, Navigatable {
 extension SwitchableViewController: SwitchSyncable {
     
     func syncSwitchWith(nextVC: SwitchableViewController) {
+        nextVC.isManager = self.isManager
         nextVC.switchStatusWhenWillAppear = isSwitchOn
         nextVC.syncSwitchReverse = { sender in
             self.switchStatusWhenWillAppear = nextVC.isSwitchOn


### PR DESCRIPTION
1 스터디 수정을 위한 VC 분리 ( rename StudyGeneralRule -> CreatingStudyGeneralRule, add EditingStudyGeneralRule)
2 스터디 벌금규칙 dimmingView 추가
3 RoundedNumberField의 textFieldDelegate를 외부에서 지정해주었을경우 textFieldBeginEditing에서 호출할 pickerSelectRowMatchedTextIn(_ TextField) 추가
4 Study 정보 수정에서 값이 변경되지않으면 확인버튼을 통해 업데이트할 필요가 없으므로 확인버튼 비활성화를 위한 Equatable protocol 추가
5 스터디 규칙간 separateLine 추가
6 화면 전환간 isManager를 전달하기위한 코드를 SwitchableVC의 syncSwitchWith(nextVC)에 추가
